### PR TITLE
bump node:6 to node:6.2

### DIFF
--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.0
+FROM node:6.2
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.0
+FROM node:6.2
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh

--- a/6.2/imagemagick-policy.xml
+++ b/6.2/imagemagick-policy.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policymap [
+<!ELEMENT policymap (policy)+>
+<!ELEMENT policy (#PCDATA)>
+<!ATTLIST policy domain (delegate|coder|filter|path|resource) #IMPLIED>
+<!ATTLIST policy name CDATA #IMPLIED>
+<!ATTLIST policy rights CDATA #IMPLIED>
+<!ATTLIST policy pattern CDATA #IMPLIED>
+<!ATTLIST policy value CDATA #IMPLIED>
+]>
+<!--
+  Configure ImageMagick policies.
+
+  Domains include system, delegate, coder, filter, path, or resource.
+
+  Rights include none, read, write, and execute.  Use | to combine them,
+  for example: "read | write" to permit read from, or write to, a path.
+
+  Use a glob expression as a pattern.
+
+  Suppose we do not want users to process MPEG video images:
+
+    <policy domain="delegate" rights="none" pattern="mpeg:decode" />
+
+  Here we do not want users reading images from HTTP:
+
+    <policy domain="coder" rights="none" pattern="HTTP" />
+
+  Lets prevent users from executing any image filters:
+
+    <policy domain="filter" rights="none" pattern="*" />
+
+  The /repository file system is restricted to read only.  We use a glob
+  expression to match all paths that start with /repository:
+
+    <policy domain="path" rights="read" pattern="/repository/*" />
+
+  Any large image is cached to disk rather than memory:
+
+    <policy domain="resource" name="area" value="1GB"/>
+
+  Define arguments for the memory, map, area, width, height, and disk resources
+  with SI prefixes (.e.g 100MB).  In addition, resource policies are maximums
+  for each instance of ImageMagick (e.g. policy memory limit 1GB, -limit 2GB
+  exceeds policy maximum so memory limit is 1GB).
+-->
+<policymap>
+  <policy domain="coder" rights="none" pattern="EPHEMERAL" />
+  <policy domain="coder" rights="none" pattern="HTTPS" />
+  <policy domain="coder" rights="none" pattern="HTTP" />
+  <policy domain="coder" rights="none" pattern="URL" />
+  <policy domain="coder" rights="none" pattern="FTP" />
+  <policy domain="coder" rights="none" pattern="MVG" />
+  <policy domain="coder" rights="none" pattern="MSL" />
+  <policy domain="coder" rights="none" pattern="TEXT" />
+  <policy domain="coder" rights="none" pattern="LABEL" />
+  <policy domain="coder" rights="none" pattern="SHOW" />
+  <policy domain="coder" rights="none" pattern="WIN" />
+  <policy domain="coder" rights="none" pattern="PLT" />
+  <policy domain="path" rights="none" pattern="@*" />
+  <policy domain="cache" name="shared-secret" value="passphrase"/>
+</policymap>


### PR DESCRIPTION
Hey All - Very similar to @flintinatux comments the other day in the #tooling channel, we want to run on node 6 without babel.  

To achieve this, we need to bump our Node Docker image version.  

The question is, (and after lurking in the discussion in the #tooling channel) do we just go to 6.2 or 6.3? or do we even care and just do 6.x?

Would like to start a discussion about it, since in my non-docker-expert opinion if you do 6.x (aka Node:6) you'll always get the latest when you do a build...but point releases could have some big consequences.  Curious to hash this out! Thanks

cc: @tecnobrat @flintinatux @evilsoft @pklingem @fromonesrc 