### PR TITLE
install yarn via npm

### DIFF
--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:4.4
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
 
+RUN npm install -g yarn
+ENV PATH="${PATH}:${HOME}/.yarn/bin"
+
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 

--- a/5.11/Dockerfile
+++ b/5.11/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:5.11
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
 
+RUN npm install -g yarn
+ENV PATH="${PATH}:${HOME}/.yarn/bin"
+
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:6.0
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
 
+RUN npm install -g yarn
+ENV PATH="${PATH}:${HOME}/.yarn/bin"
+
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:6.2
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
 
+RUN npm install -g yarn
+ENV PATH="${PATH}:${HOME}/.yarn/bin"
+
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:6
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
 
+RUN npm install -g yarn
+ENV PATH="${PATH}:${HOME}/.yarn/bin"
+
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 


### PR DESCRIPTION
![yarn](http://data.whicdn.com/images/39519431/large.gif)

I tinkered with installing via apt, but it was a pain trying to import the gpg key.  The base node images install `npm` anyway, so there's no harm in installing via `npm` in my opinion.