### PR TITLE
install yarn from apt repo

### DIFF
--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -1,7 +1,12 @@
 FROM node:4.4
 
-RUN npm install -g yarn@0.17.4
-ENV PATH="${PATH}:${HOME}/.yarn/bin"
+RUN apt-get update && \
+    apt-get install apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
+    apt-get install yarn && \
+    apt-get clean
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh

--- a/5.11/Dockerfile
+++ b/5.11/Dockerfile
@@ -1,7 +1,12 @@
 FROM node:5.11
 
-RUN npm install -g yarn@0.17.4
-ENV PATH="${PATH}:${HOME}/.yarn/bin"
+RUN apt-get update && \
+    apt-get install apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
+    apt-get install yarn && \
+    apt-get clean
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -1,7 +1,12 @@
 FROM node:6.0
 
-RUN npm install -g yarn@0.17.4
-ENV PATH="${PATH}:${HOME}/.yarn/bin"
+RUN apt-get update && \
+    apt-get install apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
+    apt-get install yarn && \
+    apt-get clean
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -1,7 +1,12 @@
 FROM node:6.2
 
-RUN npm install -g yarn@0.17.4
-ENV PATH="${PATH}:${HOME}/.yarn/bin"
+RUN apt-get update && \
+    apt-get install apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
+    apt-get install yarn && \
+    apt-get clean
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -1,7 +1,12 @@
 FROM node:6
 
-RUN npm install -g yarn@0.17.4
-ENV PATH="${PATH}:${HOME}/.yarn/bin"
+RUN apt-get update && \
+    apt-get install apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
+    apt-get install yarn && \
+    apt-get clean
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -1,7 +1,12 @@
 FROM node:7
 
-RUN npm install -g yarn@0.17.4
-ENV PATH="${PATH}:${HOME}/.yarn/bin"
+RUN apt-get update && \
+    apt-get install apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
+    apt-get install yarn && \
+    apt-get clean
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -1,11 +1,12 @@
 FROM node:7
 
 RUN apt-get update && \
-    apt-get install apt-transport-https && \
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    apt-get install apt-transport-https
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
-    apt-get install yarn && \
+    apt-get install yarn=0.19.1-1 && \
     apt-get clean
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh


### PR DESCRIPTION
we should consider installing yarn from the apt repo as the yarn maintainers suggest.  It feels wrong to install via npm anyway.  The only downside is that we can't lock the version down if we want to.  @articulate/ops what are your thoughts?