### PR TITLE
bump yarn to 0.23.1

### DIFF
--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
-    apt-get install -y yarn=0.19.1-1 && \
+    apt-get install -y yarn=0.23.1-1 && \
     apt-get clean
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh

--- a/5.11/Dockerfile
+++ b/5.11/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
-    apt-get install -y yarn=0.19.1-1 && \
+    apt-get install -y yarn=0.23.1-1 && \
     apt-get clean
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
-    apt-get install -y yarn=0.19.1-1 && \
+    apt-get install -y yarn=0.23.1-1 && \
     apt-get clean
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
-    apt-get install -y yarn=0.19.1-1 && \
+    apt-get install -y yarn=0.23.1-1 && \
     apt-get clean
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
-    apt-get install -y yarn=0.19.1-1 && \
+    apt-get install -y yarn=0.23.1-1 && \
     apt-get clean
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
-    apt-get install -y yarn=0.19.1-1 && \
+    apt-get install -y yarn=0.23.1-1 && \
     apt-get clean
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh


### PR DESCRIPTION
this version of yarn includes the `yarn import` command which will import the versions of node modules specified in `npm-shrinkwrap.json` into `yarn.lock` so no versions of packages will be changed when switching from shrinkwrap to yarn.  see: https://github.com/yarnpkg/yarn/pull/2580

![yarn](https://1.bp.blogspot.com/-aF9Av742XjA/UhAqLZWsLhI/AAAAAAAAE5g/R6KiOvjGt5I/s640/IMG_6423.jpg)