### PR TITLE
Service user and homedir

### DIFF
--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:4.4
 
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
 RUN apt-get update && \
     apt-get install -y apt-transport-https
 
@@ -11,5 +14,8 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+RUN useradd --home $SERVICE_ROOT -ms /bin/bash $SERVICE_USER
+WORKDIR $SERVICE_ROOT
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 
-RUN useradd --home $SERVICE_ROOT -ms /bin/bash $SERVICE_USER
+RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
 WORKDIR $SERVICE_ROOT
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/5.11/Dockerfile
+++ b/5.11/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 
-RUN useradd --home $SERVICE_ROOT -ms /bin/bash $SERVICE_USER
+RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
 WORKDIR $SERVICE_ROOT
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/5.11/Dockerfile
+++ b/5.11/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:5.11
 
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
 RUN apt-get update && \
     apt-get install -y apt-transport-https
 
@@ -11,5 +14,8 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+RUN useradd --home $SERVICE_ROOT -ms /bin/bash $SERVICE_USER
+WORKDIR $SERVICE_ROOT
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 
-RUN useradd --home $SERVICE_ROOT -ms /bin/bash $SERVICE_USER
+RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
 WORKDIR $SERVICE_ROOT
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:6.0
 
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
 RUN apt-get update && \
     apt-get install -y apt-transport-https
 
@@ -11,5 +14,8 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+RUN useradd --home $SERVICE_ROOT -ms /bin/bash $SERVICE_USER
+WORKDIR $SERVICE_ROOT
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 
-RUN useradd --home $SERVICE_ROOT -ms /bin/bash $SERVICE_USER
+RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
 WORKDIR $SERVICE_ROOT
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:6.2
 
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
 RUN apt-get update && \
     apt-get install -y apt-transport-https
 
@@ -11,5 +14,8 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+RUN useradd --home $SERVICE_ROOT -ms /bin/bash $SERVICE_USER
+WORKDIR $SERVICE_ROOT
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 
-RUN useradd --home $SERVICE_ROOT -ms /bin/bash $SERVICE_USER
+RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
 WORKDIR $SERVICE_ROOT
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:6
 
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
 RUN apt-get update && \
     apt-get install -y apt-transport-https
 
@@ -11,5 +14,8 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+RUN useradd --home $SERVICE_ROOT -ms /bin/bash $SERVICE_USER
+WORKDIR $SERVICE_ROOT
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 
-RUN useradd --home $SERVICE_ROOT -ms /bin/bash $SERVICE_USER
+RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
 WORKDIR $SERVICE_ROOT
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:7
 
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
 RUN apt-get update && \
     apt-get install -y apt-transport-https
 
@@ -11,5 +14,8 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+RUN useradd --home $SERVICE_ROOT -ms /bin/bash $SERVICE_USER
+WORKDIR $SERVICE_ROOT
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build_6:
+	docker build -t articulate/articulate-node:6 6/
+
+build_7:
+	docker build -t articulate/articulate-node:7 7/


### PR DESCRIPTION
Allows us to limit our permissions to the app. To use, the app will need to set `USER` and `RUN chown` on the service dir. Example:

```
FROM articulate/articulate-node:6

COPY package.json yarn.lock $SERVICE_ROOT/
RUN yarn install --pure-lockfile
COPY . $SERVICE_ROOT/

RUN chown -R $SERVICE_USER /$SERVICE_ROOT
USER $SERVICE_USER

EXPOSE 3000
CMD yarn run rest
```