### PR TITLE
Add in node-gyp global

### DIFF
--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -28,4 +28,6 @@ WORKDIR $SERVICE_ROOT
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
 
+RUN yarn global add node-gyp
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/5.11/Dockerfile
+++ b/5.11/Dockerfile
@@ -28,4 +28,6 @@ WORKDIR $SERVICE_ROOT
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
 
+RUN yarn global add node-gyp
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -28,4 +28,6 @@ WORKDIR $SERVICE_ROOT
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
 
+RUN yarn global add node-gyp
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -28,4 +28,6 @@ WORKDIR $SERVICE_ROOT
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
 
+RUN yarn global add node-gyp
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -28,4 +28,6 @@ WORKDIR $SERVICE_ROOT
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
 
+RUN yarn global add node-gyp
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -28,4 +28,6 @@ WORKDIR $SERVICE_ROOT
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
 
+RUN yarn global add node-gyp
+
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Want to use new-relic native metrics stuff?  You will need `node-gyp` installed globally, otherwise it pukes. 

So this adds it to our default installs! 

🚢 
