### PR TITLE
Use NPM_TOKEN to access private modules

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -1,8 +1,11 @@
 FROM node:4.4
+ARG NPM_TOKEN=secret
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
+
+ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/npm-token/.npmrc ${SERVICE_ROOT}/.npmrc
 
 RUN set -ex \
   && for key in \

--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -5,7 +5,7 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
 
-ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/npm-token/.npmrc ${SERVICE_ROOT}/.npmrc
+ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/master/.npmrc ${SERVICE_ROOT}/.npmrc
 
 RUN set -ex \
   && for key in \

--- a/5.11/Dockerfile
+++ b/5.11/Dockerfile
@@ -5,7 +5,7 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
 
-ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/npm-token/.npmrc ${SERVICE_ROOT}/.npmrc
+ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/master/.npmrc ${SERVICE_ROOT}/.npmrc
 
 RUN set -ex \
   && for key in \

--- a/5.11/Dockerfile
+++ b/5.11/Dockerfile
@@ -1,8 +1,11 @@
 FROM node:5.11
+ARG NPM_TOKEN=secret
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
+
+ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/npm-token/.npmrc ${SERVICE_ROOT}/.npmrc
 
 RUN set -ex \
   && for key in \

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -5,7 +5,7 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.22.0
 
-ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/npm-token/.npmrc ${SERVICE_ROOT}/.npmrc
+ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/master/.npmrc ${SERVICE_ROOT}/.npmrc
 
 RUN set -ex \
   && for key in \

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -1,8 +1,11 @@
 FROM node:6.0
+ARG NPM_TOKEN=secret
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.22.0
+
+ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/npm-token/.npmrc ${SERVICE_ROOT}/.npmrc
 
 RUN set -ex \
   && for key in \

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -1,8 +1,11 @@
 FROM node:6.2
+ARG NPM_TOKEN=secret
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
+
+ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/npm-token/.npmrc ${SERVICE_ROOT}/.npmrc
 
 RUN set -ex \
   && for key in \

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -5,7 +5,7 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
 
-ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/npm-token/.npmrc ${SERVICE_ROOT}/.npmrc
+ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/master/.npmrc ${SERVICE_ROOT}/.npmrc
 
 RUN set -ex \
   && for key in \

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -5,7 +5,7 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
 
-ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/npm-token/.npmrc ${SERVICE_ROOT}/.npmrc
+ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/master/.npmrc ${SERVICE_ROOT}/.npmrc
 
 RUN set -ex \
   && for key in \

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -1,8 +1,11 @@
 FROM node:6
+ARG NPM_TOKEN=secret
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
+
+ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/npm-token/.npmrc ${SERVICE_ROOT}/.npmrc
 
 RUN set -ex \
   && for key in \

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -1,8 +1,11 @@
 FROM node:7
+ARG NPM_TOKEN=secret
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
+
+ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/npm-token/.npmrc ${SERVICE_ROOT}/.npmrc
 
 RUN set -ex \
   && for key in \

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -5,7 +5,7 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
 
-ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/npm-token/.npmrc ${SERVICE_ROOT}/.npmrc
+ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/master/.npmrc ${SERVICE_ROOT}/.npmrc
 
 RUN set -ex \
   && for key in \

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -1,8 +1,11 @@
 FROM node:8
+ARG NPM_TOKEN=secret
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
+
+ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/npm-token/.npmrc ${SERVICE_ROOT}/.npmrc
 
 RUN set -ex \
   && for key in \

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -5,7 +5,7 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
 
-ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/npm-token/.npmrc ${SERVICE_ROOT}/.npmrc
+ADD https://raw.githubusercontent.com/articulate/docker-articulate-node/master/.npmrc ${SERVICE_ROOT}/.npmrc
 
 RUN set -ex \
   && for key in \


### PR DESCRIPTION
![insert token](http://vignette2.wikia.nocookie.net/gravityfalls/images/3/3c/S1e10_insert_token.png/revision/latest?cb=20120921235218)

See [the docs](https://docs.npmjs.com/private-modules/ci-server-config) for details.  I've tested this locally with a :magic: branch of `rise-runtime`.