### PR TITLE
Updating to Debian Stretch

### DIFF
--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.0
+FROM node:6.0-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service


### PR DESCRIPTION
This will fix multiple CVE's (https://mailinglist-archive.mojah.be/debian-security/2017-08/msg00034.php) if you are using ffmpeg or libav-tools. The base images will be updated from Debian Jessie (8) to Stretch (9). Stretch contains the latest ffmpeg security release. 