### PR TITLE
Revert "bump yarn to 1.0.1"

### DIFF
--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -2,7 +2,7 @@ FROM node:4.4
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.0.1 
+ENV YARN_VERSION 0.27.5
 
 RUN set -ex \
   && for key in \

--- a/5.11/Dockerfile
+++ b/5.11/Dockerfile
@@ -2,7 +2,7 @@ FROM node:5.11
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.0.1 
+ENV YARN_VERSION 0.27.5
 
 RUN set -ex \
   && for key in \

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -2,7 +2,7 @@ FROM node:6.0
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.0.1 
+ENV YARN_VERSION 0.22.0
 
 RUN set -ex \
   && for key in \

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -2,7 +2,7 @@ FROM node:6.2
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.0.1 
+ENV YARN_VERSION 0.27.5
 
 RUN set -ex \
   && for key in \

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -2,7 +2,7 @@ FROM node:6
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.0.1 
+ENV YARN_VERSION 0.27.5
 
 RUN set -ex \
   && for key in \

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -2,7 +2,7 @@ FROM node:7
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.0.1 
+ENV YARN_VERSION 0.27.5
 
 RUN set -ex \
   && for key in \

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -2,7 +2,7 @@ FROM node:8
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.0.1 
+ENV YARN_VERSION 0.27.5
 
 RUN set -ex \
   && for key in \


### PR DESCRIPTION
yarn 1.0.1 is causing some problems with private npm module installs due to https://github.com/yarnpkg/yarn/issues/4335 - let's roll it back for now