### PR TITLE
Swap to stretch as default, setup jessie as backup

### DIFF
--- a/5.11-jessie/Dockerfile
+++ b/5.11-jessie/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:5.11-stretch
+FROM node:5.11
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service

--- a/5.11/Dockerfile
+++ b/5.11/Dockerfile
@@ -4,6 +4,10 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
 
+RUN apt-get update -qq && \
+  apt-get upgrade -y && \
+  rm -rf /var/lib/apt/lists/*
+
 RUN set -ex \
   && for key in \
     6A010C5166006599AA17F08146C2130DFD2497F5 \

--- a/6-jessie/Dockerfile
+++ b/6-jessie/Dockerfile
@@ -1,8 +1,12 @@
-FROM node:5.11-stretch
+FROM node:6
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
+
+RUN apt-get update -qq && \
+  apt-get upgrade -y && \
+  rm -rf /var/lib/apt/lists/*
 
 RUN set -ex \
   && for key in \

--- a/6.0-jessie/Dockerfile
+++ b/6.0-jessie/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:5.11-stretch
+FROM node:6.0
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 0.27.5
+ENV YARN_VERSION 0.22.0
 
 RUN set -ex \
   && for key in \

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -4,6 +4,10 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.22.0
 
+RUN apt-get update -qq && \
+  apt-get upgrade -y && \
+  rm -rf /var/lib/apt/lists/*
+
 RUN set -ex \
   && for key in \
     6A010C5166006599AA17F08146C2130DFD2497F5 \

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.0
+FROM node:6.0-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service

--- a/6.2-jessie/Dockerfile
+++ b/6.2-jessie/Dockerfile
@@ -1,8 +1,12 @@
-FROM node:5.11-stretch
+FROM node:6.2
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
+
+RUN apt-get update -qq && \
+  apt-get upgrade -y && \
+  rm -rf /var/lib/apt/lists/*
 
 RUN set -ex \
   && for key in \

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -4,6 +4,10 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
 
+RUN apt-get update -qq && \
+  apt-get upgrade -y && \
+  rm -rf /var/lib/apt/lists/*
+
 RUN set -ex \
   && for key in \
     6A010C5166006599AA17F08146C2130DFD2497F5 \

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.2
+FROM node:6.2-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -4,6 +4,10 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
 
+RUN apt-get update -qq && \
+  apt-get upgrade -y && \
+  rm -rf /var/lib/apt/lists/*
+
 RUN set -ex \
   && for key in \
     6A010C5166006599AA17F08146C2130DFD2497F5 \

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6
+FROM node:6-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service

--- a/7-jessie/Dockerfile
+++ b/7-jessie/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-stretch
+FROM node:7
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:7
+FROM node:7-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -4,6 +4,10 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
 
+RUN apt-get update -qq && \
+  apt-get upgrade -y && \
+  rm -rf /var/lib/apt/lists/*
+
 RUN set -ex \
   && for key in \
     6A010C5166006599AA17F08146C2130DFD2497F5 \

--- a/8-jessie/Dockerfile
+++ b/8-jessie/Dockerfile
@@ -1,8 +1,12 @@
-FROM node:4.4
+FROM node:8
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
+
+RUN apt-get update -qq && \
+  apt-get upgrade -y && \
+  rm -rf /var/lib/apt/lists/*
 
 RUN set -ex \
   && for key in \

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -4,6 +4,10 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 0.27.5
 
+RUN apt-get update -qq && \
+  apt-get upgrade -y && \
+  rm -rf /var/lib/apt/lists/*
+
 RUN set -ex \
   && for key in \
     6A010C5166006599AA17F08146C2130DFD2497F5 \

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:8-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service


### PR DESCRIPTION
This creates images for `[version_number]-jessie` and moves all of the `[version_number]` tagged image to inherit on the stretch images instead.