### PR TITLE
Bump yarn version to 1.5.1

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -2,7 +2,7 @@ FROM node:4-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.3.2
+ENV YARN_VERSION 1.5.1
 
 RUN apt-get update -qq && \
   apt-get upgrade -y && \

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -2,7 +2,7 @@ FROM node:6-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.3.2
+ENV YARN_VERSION 1.5.1
 
 RUN apt-get update -qq && \
   apt-get upgrade -y && \

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -2,7 +2,7 @@ FROM node:8-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.3.2
+ENV YARN_VERSION 1.5.1
 
 RUN apt-get update -qq && \
   apt-get upgrade -y && \

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
+default: build_4 build_6 build_8
+
+build_4:
+	docker build -t local/articulate-node:4 4/
+
 build_6:
 	docker build -t local/articulate-node:6 6/
-
-build_6-stretch:
-	docker build -t local/articulate-node:6-stretch 6-stretch/
-
-build_7:
-	docker build -t local/articulate-node:7 7/
 
 build_8:
 	docker build -t local/articulate-node:8 8/

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 build_6:
-	docker build -t articulate/articulate-node:6 6/
+	docker build -t local/articulate-node:6 6/
 
 build_6-stretch:
-	docker build -t articulate/articulate-node:6-stretch 6-stretch/
+	docker build -t local/articulate-node:6-stretch 6-stretch/
 
 build_7:
-	docker build -t articulate/articulate-node:7 7/
+	docker build -t local/articulate-node:7 7/
 
 build_8:
-	docker build -t articulate/articulate-node:8 8/
+	docker build -t local/articulate-node:8 8/

--- a/README.md
+++ b/README.md
@@ -3,3 +3,18 @@
 Base node image which contains common dependencies used in our organization.
 
 These are all built on Dockerhub as Automated Builds.
+
+## To test locally
+
+1. Run `make` to build a `local/articulate-node` image locally
+2. Change the first line of your `Dockerfile` to be:
+
+```
+FROM local/articulate-node
+```
+
+3. Then
+
+```
+docker-compose build --no-cache && docker-compose up
+```


### PR DESCRIPTION
Description:
- bump our version of `yarn` from `1.3.2` to `1.5.1`
- take advantage of bug and compatibility fixes/improvements
- change makefile so build path is `local/{image name}` (imo makes testing locally much easier)

Test:
- build locally
- tie a local repo to the new image and make sure all packages install (especially private and scoped)