### PR TITLE
Bump yarn 1.6.0

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -2,7 +2,7 @@ FROM node:4-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.5.1
+ENV YARN_VERSION 1.6.0
 
 RUN apt-get update -qq && \
   apt-get upgrade -y && \

--- a/6-alpine/Dockerfile
+++ b/6-alpine/Dockerfile
@@ -2,8 +2,27 @@ FROM node:6-alpine
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
+ENV YARN_VERSION 1.6.0
 
 RUN apk update && apk add bash make gcc
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -2,7 +2,7 @@ FROM node:6-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.5.1
+ENV YARN_VERSION 1.6.0
 
 RUN apt-get update -qq && \
   apt-get upgrade -y && \

--- a/8-alpine/Dockerfile
+++ b/8-alpine/Dockerfile
@@ -26,7 +26,6 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
-RUN npm install --global yarn
 
 RUN addgroup $SERVICE_USER && adduser -h $SERVICE_ROOT -G $SERVICE_USER -s /bin/bash $SERVICE_USER -D
 WORKDIR $SERVICE_ROOT

--- a/8-alpine/Dockerfile
+++ b/8-alpine/Dockerfile
@@ -2,8 +2,27 @@ FROM node:8-alpine
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
+ENV YARN_VERSION 1.6.0
 
 RUN apk update && apk add bash make gcc
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -2,7 +2,7 @@ FROM node:8-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.5.1
+ENV YARN_VERSION 1.6.0
 
 RUN apt-get update -qq && \
   apt-get upgrade -y && \

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,11 @@ build_4:
 build_6:
 	docker build -t local/articulate-node:6 6/
 
+build_6-alpine:
+	docker build -t local/articulate-node:6-alpine 6-alpine/
+
 build_8:
 	docker build -t local/articulate-node:8 8/
+
+build_8-alpine:
+	docker build -t local/articulate-node:8-alpine 8-alpine/


### PR DESCRIPTION
- we like yarn, we like updated and consistent yarn best.
- bump yarn to 1.6.0, and lock it there.
- add this to our new alpine images.