### PR TITLE
Add g++ to alpine images for native module building

### DIFF
--- a/6-alpine/Dockerfile
+++ b/6-alpine/Dockerfile
@@ -4,7 +4,7 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 1.6.0
 
-RUN apk update && apk add bash make gcc
+RUN apk update && apk add bash make gcc g++
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && for key in \

--- a/8-alpine/Dockerfile
+++ b/8-alpine/Dockerfile
@@ -4,7 +4,7 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 1.6.0
 
-RUN apk update && apk add bash make gcc
+RUN apk update && apk add bash make gcc g++
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && for key in \


### PR DESCRIPTION
- Our alpine images were not building native modules.
- This fixes that up, and will take care of any that have already been shipped.

cc: @pimpolderman 