### PR TITLE
Node 8 lambda

### DIFF
--- a/8-lambda/Dockerfile
+++ b/8-lambda/Dockerfile
@@ -1,0 +1,30 @@
+FROM amazonlinux:2017.03.1.20170812
+
+ENV NODE_VERSION 8.10.0
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+ENV YARN_VERSION 1.6.0
+
+RUN curl --silent --location https://rpm.nodesource.com/setup_8.x | bash - && \
+    yum install -y nodejs-$NODE_VERSION
+
+RUN curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
+    yum install -y yarn-$YARN_VERSION
+
+RUN yarn global add \
+      aws-sdk@2.221.1 \
+      node-gyp \
+      nodemon
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+## TODO: ask platform if this is needed
+# RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
+WORKDIR $SERVICE_ROOT
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+RUN chmod a+rx /wait-for-it.sh
+
+## TODO: need to `yarn link aws-sdk` in an entrypoint file (post build)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/8-lambda/Dockerfile
+++ b/8-lambda/Dockerfile
@@ -5,26 +5,26 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 1.6.0
 
-RUN curl --silent --location https://rpm.nodesource.com/setup_8.x | bash - && \
-    yum install -y nodejs-$NODE_VERSION
+RUN curl --silent --location https://rpm.nodesource.com/setup_8.x | bash -
+RUN curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo
 
-RUN curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
-    yum install -y yarn-$YARN_VERSION
+RUN yum install -y \
+      nodejs-$NODE_VERSION \
+      shadow-utils \
+      yarn-$YARN_VERSION
 
 RUN npm i -g \
       aws-sdk@2.221.1 \
-      node-gyp \
-      nodemon
+      node-gyp
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 
-## TODO: ask platform if this is needed
-# RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
+RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
 WORKDIR $SERVICE_ROOT
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
 
-## TODO: need to `npm link aws-sdk` in an entrypoint file (post build)
-ENTRYPOINT ["/entrypoint.sh"]
+COPY entrypoint-lambda.sh /
+ENTRYPOINT ["/entrypoint-lambda.sh"]

--- a/8-lambda/Dockerfile
+++ b/8-lambda/Dockerfile
@@ -11,7 +11,7 @@ RUN curl --silent --location https://rpm.nodesource.com/setup_8.x | bash - && \
 RUN curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
     yum install -y yarn-$YARN_VERSION
 
-RUN yarn global add \
+RUN npm i -g \
       aws-sdk@2.221.1 \
       node-gyp \
       nodemon
@@ -26,5 +26,5 @@ WORKDIR $SERVICE_ROOT
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
 
-## TODO: need to `yarn link aws-sdk` in an entrypoint file (post build)
+## TODO: need to `npm link aws-sdk` in an entrypoint file (post build)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/8-lambda/Dockerfile
+++ b/8-lambda/Dockerfile
@@ -1,8 +1,10 @@
 FROM lambci/lambda:build-nodejs8.10
 
+ENV AWS_DEFAULT_REGION us-east-1
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.6.0
+ENV SHELL bash
+ENV YARN_VERSION 1.10.1
 
 RUN curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo
 
@@ -11,7 +13,7 @@ RUN yum install -y \
   yarn-$YARN_VERSION
 
 RUN npm i -g \
-      aws-sdk@2.221.1 \
+      aws-sdk \
       node-gyp
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh

--- a/8-lambda/Dockerfile
+++ b/8-lambda/Dockerfile
@@ -4,6 +4,8 @@ ENV AWS_DEFAULT_REGION us-east-1
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV SHELL bash
+
+ENV AWS_SDK_VERSION 2.290.0
 ENV YARN_VERSION 1.10.1
 
 RUN curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo
@@ -13,8 +15,8 @@ RUN yum install -y \
   yarn-$YARN_VERSION
 
 RUN npm i -g \
-      aws-sdk \
-      node-gyp
+  aws-sdk@$AWS_SDK_VERSION \
+  node-gyp
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh

--- a/8-lambda/Dockerfile
+++ b/8-lambda/Dockerfile
@@ -1,17 +1,14 @@
-FROM amazonlinux:2017.03.1.20170812
+FROM lambci/lambda:build-nodejs8.10
 
-ENV NODE_VERSION 8.10.0
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 1.6.0
 
-RUN curl --silent --location https://rpm.nodesource.com/setup_8.x | bash -
 RUN curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo
 
 RUN yum install -y \
-      nodejs-$NODE_VERSION \
-      shadow-utils \
-      yarn-$YARN_VERSION
+  libtasn \
+  yarn-$YARN_VERSION
 
 RUN npm i -g \
       aws-sdk@2.221.1 \

--- a/8-lambda/entrypoint-lambda.sh
+++ b/8-lambda/entrypoint-lambda.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+npm link aws-sdk
+/entrypoint.sh "$@"

--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,8 @@ build_8:
 build_8-alpine:
 	docker build -t local/articulate-node:8-alpine 8-alpine/
 
+build_8-lambda:
+	docker build -t local/articulate-node:8-lambda 8-lambda/
+
 build_10-alpine:
 	docker build -t local/articulate-node:10-alpine 10-alpine/


### PR DESCRIPTION
![dilbert lambda](https://pbs.twimg.com/media/CSeqzDRU8AAClCg.png)

I want this for dev'ing and deploying lambda stuffs.  Uses the legit `amazonlinux` image and links the `aws-sdk` used in the real lambda environment (can [check my work here](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html)).  Also pulls in our Consul magic, so we can env like we always do.