### PR TITLE
Remove npm and yarn install

### DIFF
--- a/6-alpine/Dockerfile
+++ b/6-alpine/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:6-alpine
 
-RUN npm uninstall npm -g
-
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
@@ -18,6 +16,7 @@ WORKDIR $SERVICE_ROOT
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
 
+RUN npm install npm -g
 RUN yarn global add node-gyp
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/6-alpine/Dockerfile
+++ b/6-alpine/Dockerfile
@@ -4,31 +4,10 @@ RUN npm uninstall npm -g
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.6.0
 
 RUN apk add --no-cache bash make gcc g++ binutils jq sudo unzip 
 
-RUN apk upgrade --no-cache binutils jq sudo unzip 
-
-RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
-  && for key in \
-    6A010C5166006599AA17F08146C2130DFD2497F5 \
-  ; do \
-    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
-  done \
-  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
-  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-  && mkdir -p /opt \
-  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-  && rm -rf /usr/local/bin/yarn \
-  && rm -rf /usr/local/bin/yarnpkg \
-  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-  && apk del .build-deps-yarn
+RUN apk upgrade --no-cache binutils jq sudo unzip
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh

--- a/6-alpine/Dockerfile
+++ b/6-alpine/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:6-alpine
 
+RUN npm uninstall npm -g
+
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 1.6.0

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -4,26 +4,10 @@ RUN npm uninstall npm -g
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.6.0
 
 RUN apt-get update -qq && \
   apt-get upgrade -y && \
   rm -rf /var/lib/apt/lists/*
-
-RUN set -ex \
-  && for key in \
-    6A010C5166006599AA17F08146C2130DFD2497F5 \
-  ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
-  done \
-  && curl -fSL -o yarn.js "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-legacy-$YARN_VERSION.js" \
-  && curl -fSL -o yarn.js.asc "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-legacy-$YARN_VERSION.js.asc" \
-  && gpg --batch --verify yarn.js.asc yarn.js \
-  && rm yarn.js.asc \
-  && mv yarn.js /usr/local/bin/yarn \
-  && chmod +x /usr/local/bin/yarn
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:6-stretch
 
+RUN npm uninstall npm -g
+
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 1.6.0

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:6-stretch
 
-RUN npm uninstall npm -g
-
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
@@ -18,6 +16,7 @@ WORKDIR $SERVICE_ROOT
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
 
+RUN npm install npm -g
 RUN yarn global add node-gyp
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/8-alpine/Dockerfile
+++ b/8-alpine/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:8-alpine
 
+RUN npm uninstall npm -g
+
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 1.6.0

--- a/8-alpine/Dockerfile
+++ b/8-alpine/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:8-alpine
 
-RUN npm uninstall npm -g
-
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
@@ -18,6 +16,7 @@ WORKDIR $SERVICE_ROOT
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
 
+RUN npm install npm -g
 RUN yarn global add node-gyp
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/8-alpine/Dockerfile
+++ b/8-alpine/Dockerfile
@@ -4,31 +4,10 @@ RUN npm uninstall npm -g
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.6.0
 
 RUN apk add --no-cache bash make gcc g++ binutils jq sudo unzip 
 
-RUN apk upgrade --no-cache binutils jq sudo unzip 
-
-RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
-  && for key in \
-    6A010C5166006599AA17F08146C2130DFD2497F5 \
-  ; do \
-    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
-  done \
-  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
-  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-  && mkdir -p /opt \
-  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-  && rm -rf /usr/local/bin/yarn \
-  && rm -rf /usr/local/bin/yarnpkg \
-  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-  && apk del .build-deps-yarn
+RUN apk upgrade --no-cache binutils jq sudo unzip
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:8-stretch
 
+RUN npm uninstall npm -g
+
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV YARN_VERSION 1.6.0

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -4,26 +4,10 @@ RUN npm uninstall npm -g
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV YARN_VERSION 1.6.0
 
 RUN apt-get update -qq && \
   apt-get upgrade -y && \
   rm -rf /var/lib/apt/lists/*
-
-RUN set -ex \
-  && for key in \
-    6A010C5166006599AA17F08146C2130DFD2497F5 \
-  ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
-  done \
-  && curl -fSL -o yarn.js "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-legacy-$YARN_VERSION.js" \
-  && curl -fSL -o yarn.js.asc "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-legacy-$YARN_VERSION.js.asc" \
-  && gpg --batch --verify yarn.js.asc yarn.js \
-  && rm yarn.js.asc \
-  && mv yarn.js /usr/local/bin/yarn \
-  && chmod +x /usr/local/bin/yarn
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:8-stretch
 
-RUN npm uninstall npm -g
-
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
@@ -18,6 +16,7 @@ WORKDIR $SERVICE_ROOT
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
 
+RUN npm install npm -g
 RUN yarn global add node-gyp
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Removing `npm` from all our node `6` and `8` docker images since we're using `yarn` pretty much across the board on everything now; this is to address some vulnerabilities being picked up on the `npm` module via twistlock and also clean things up.

Also removing the yarn installation from our Dockerfiles since the upstream `node` image that we're using is already installing yarn `1.6.0` for us - [example from node:8-alpine](https://github.com/nodejs/docker-node/blob/master/8/alpine/Dockerfile#L49-L67)

Example vuln report on `npm` from Twistlock:
![](http://drops.articulate.com/wTUX2Y/mn346pjKSa+)