### PR TITLE
better way to install npm globally to node 6

### DIFF
--- a/6-alpine/Dockerfile
+++ b/6-alpine/Dockerfile
@@ -2,10 +2,9 @@ FROM node:6-alpine
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
+ENV NPM_VER 6.1.0
 
-RUN apk add --no-cache bash make gcc g++ binutils jq sudo unzip 
-
-RUN apk upgrade --no-cache binutils jq sudo unzip
+RUN apk add --no-cache bash make gcc g++ binutils jq sudo unzip
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
@@ -16,7 +15,12 @@ WORKDIR $SERVICE_ROOT
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
 
-RUN npm install npm -g
+RUN npm uninstall npm -g
+
+RUN wget https://registry.npmjs.org/npm/-/npm-${NPM_VER}.tgz \
+  && tar xzf npm-${NPM_VER}.tgz \
+  && ./package/scripts/install.sh
+
 RUN yarn global add node-gyp
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -2,6 +2,7 @@ FROM node:6-stretch
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
+ENV NPM_VER 6.1.0
 
 RUN apt-get update -qq && \
   apt-get upgrade -y && \
@@ -16,7 +17,12 @@ WORKDIR $SERVICE_ROOT
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
 
-RUN npm install npm -g
+RUN npm uninstall npm -g
+
+RUN wget https://registry.npmjs.org/npm/-/npm-${NPM_VER}.tgz \
+  && tar xzf npm-${NPM_VER}.tgz \
+  && ./package/scripts/install.sh
+
 RUN yarn global add node-gyp
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
seeing this error when trying to install npm 6.1.0 on the node 6 images via `npm install npm -g`:

```
module.js:478
    throw err;
    ^

Error: Cannot find module 'isarray'
    at Function.Module._resolveFilename (module.js:476:15)
    at Function.Module._load (module.js:424:25)
    at Module.require (module.js:504:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/readable-stream/lib/_stream_readable.js:32:15)
    at Module._compile (module.js:577:32)
    at Object.Module._extensions..js (module.js:586:10)
    at Module.load (module.js:494:32)
    at tryModuleLoad (module.js:453:12)
    at Function.Module._load (module.js:445:3)
script returned exit code 1
```

Better to uninstall `npm` completely then install it via the `install.sh` script provided by `npm` to control the version being installed.