### PR TITLE
Add frontend image

### DIFF
--- a/6-alpine/Dockerfile
+++ b/6-alpine/Dockerfile
@@ -4,7 +4,17 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV NPM_VER 6.1.0
 
-RUN apk add --no-cache bash make gcc g++ binutils jq sudo unzip tar curl
+RUN apk add --no-cache \
+  bash \
+  make \
+  gcc \
+  g++ \
+  binutils \
+  jq \
+  sudo \
+  unzip \
+  tar \
+  curl
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh

--- a/8-alpine-frontend/Dockerfile
+++ b/8-alpine-frontend/Dockerfile
@@ -1,0 +1,38 @@
+FROM node:8-alpine
+
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
+RUN apk add --no-cache \
+  bash \
+  make \
+  gcc \
+  g++ \
+  binutils \
+  jq \
+  sudo \
+  unzip
+
+RUN apk add --no-cache --repository http://nl.alpinelinux.org/alpine/edge/testing \
+  consul \
+  aws-cli
+
+RUN apk upgrade --no-cache \
+  binutils \
+  jq \
+  sudo \
+  unzip
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+RUN addgroup $SERVICE_USER && adduser -h $SERVICE_ROOT -G $SERVICE_USER -s /bin/bash $SERVICE_USER -D
+WORKDIR $SERVICE_ROOT
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+RUN chmod a+rx /wait-for-it.sh
+
+RUN npm install npm -g
+RUN yarn global add node-gyp
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/8-alpine/Dockerfile
+++ b/8-alpine/Dockerfile
@@ -3,9 +3,21 @@ FROM node:8-alpine
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-RUN apk add --no-cache bash make gcc g++ binutils jq sudo unzip 
+RUN apk add --no-cache \
+  bash \
+  make \
+  gcc \
+  g++ \
+  binutils \
+  jq \
+  sudo \
+  unzip
 
-RUN apk upgrade --no-cache binutils jq sudo unzip
+RUN apk upgrade --no-cache \
+  binutils \
+  jq \
+  sudo \
+  unzip
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-default: build_6 build_6-alpine build_8 build_8-alpine
+default: ubuntu alpine
 
 ubuntu: build_6 build_8
 
-alpine: build_6-alpine build_8-alpine
+alpine: build_6-alpine build_8-alpine build_8-alpine-frontend
 
 build_6:
 	docker build -t local/articulate-node:6 6/
@@ -15,3 +15,6 @@ build_8:
 
 build_8-alpine:
 	docker build -t local/articulate-node:8-alpine 8-alpine/
+
+build_8-alpine-frontend:
+	docker build -t local/articulate-node:8-alpine-frontend 8-alpine-frontend/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-default: build_6 build_8
+default: build_6 build_6-alpine build_8 build_8-alpine
+
+ubuntu: build_6 build_8
+
+alpine: build_6-alpine build_8-alpine
 
 build_6:
 	docker build -t local/articulate-node:6 6/


### PR DESCRIPTION
![](https://media.giphy.com/media/FDDbDpUH12hDG/giphy.gif)

the only consequential change in this is the addition of the new image with:

```
RUN apk add --no-cache --repository http://nl.alpinelinux.org/alpine/edge/testing \
  consul \
  aws-cli
```

yes, this is the testing repo, and yes that is less than ideal.  The equivalent of this that we're doing in a number of frontend repos is: https://github.com/articulate/rise-platform-frontend/blob/master/Dockerfile#L3-L8 which is also less than ideal.  This is a starting point for discussion.  Regardless of how we install those (or in which repo this image lives), this will speed up builds for frontend repos and remove duplicate steps that exist across repos. 