### PR TITLE
Add `node:10-alpine` image

### DIFF
--- a/10-alpine/Dockerfile
+++ b/10-alpine/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:10-alpine
+
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
+RUN apk add --no-cache bash make gcc g++ binutils jq sudo unzip
+
+RUN apk upgrade --no-cache binutils jq sudo unzip
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+RUN addgroup $SERVICE_USER && adduser -h $SERVICE_ROOT -G $SERVICE_USER -s /bin/bash $SERVICE_USER -D
+WORKDIR $SERVICE_ROOT
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+RUN chmod a+rx /wait-for-it.sh
+
+RUN npm install npm -g
+RUN yarn global add node-gyp
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ build_8:
 
 build_8-alpine:
 	docker build -t local/articulate-node:8-alpine 8-alpine/
+
+build_10-alpine:
+	docker build -t local/articulate-node:10-alpine 10-alpine/


### PR DESCRIPTION
Description
========
node 10 is going LTS in October and I would like to start using it as the base for some upcoming PoC work and new projects.  This just gets the image created and usable locally.

* I believe this will also get us bumped to latest yarn versions on all images since this will trigger base image rebuilds. so bonus.