### PR TITLE
Lock yarn to 1.10.1 in 8-alpine,10-alpine images

### DIFF
--- a/10-alpine/Dockerfile
+++ b/10-alpine/Dockerfile
@@ -2,7 +2,6 @@ FROM node:10-alpine
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
-ENV NODE_MODULES_DIR /node_modules
 
 RUN apk add --no-cache bash make gcc g++ binutils jq sudo unzip
 
@@ -18,6 +17,10 @@ ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstra
 RUN chmod a+rx /wait-for-it.sh
 
 ENV YARN_VERSION 1.10.1
+
+ENV NODE_MODULES_DIR /node_modules
+RUN mkdir $NODE_MODULES_DIR
+RUN chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_DIR
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && for key in \

--- a/10-alpine/Dockerfile
+++ b/10-alpine/Dockerfile
@@ -2,6 +2,7 @@ FROM node:10-alpine
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
+ENV NODE_MODULES_DIR /node_modules
 
 RUN apk add --no-cache bash make gcc g++ binutils jq sudo unzip
 
@@ -15,6 +16,28 @@ WORKDIR $SERVICE_ROOT
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
+
+ENV YARN_VERSION 1.10.1
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && rm /usr/local/bin/yarn \
+  && rm /usr/local/bin/yarnpkg \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn
 
 RUN npm install npm -g
 RUN yarn global add node-gyp

--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -1,0 +1,47 @@
+FROM node:10-stretch
+
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
+RUN apt-get update -qq && \
+  apt-get upgrade -y && \
+  rm -rf /var/lib/apt/lists/*
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
+WORKDIR $SERVICE_ROOT
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+RUN chmod a+rx /wait-for-it.sh
+
+ENV YARN_VERSION 1.10.1
+
+ENV NODE_MODULES_DIR /node_modules
+RUN mkdir $NODE_MODULES_DIR
+RUN chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_DIR
+
+RUN set -ex \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && rm /usr/local/bin/yarn \
+  && rm /usr/local/bin/yarnpkg \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
+
+RUN npm install npm -g
+RUN yarn global add node-gyp
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/8-alpine/Dockerfile
+++ b/8-alpine/Dockerfile
@@ -16,6 +16,32 @@ WORKDIR $SERVICE_ROOT
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
 
+ENV YARN_VERSION 1.10.1
+
+ENV NODE_MODULES_DIR /node_modules
+RUN mkdir $NODE_MODULES_DIR
+RUN chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_DIR
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && rm /usr/local/bin/yarn \
+  && rm /usr/local/bin/yarnpkg \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn
+
 RUN npm install npm -g
 RUN yarn global add node-gyp
 

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -16,6 +16,31 @@ WORKDIR $SERVICE_ROOT
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
 RUN chmod a+rx /wait-for-it.sh
 
+ENV YARN_VERSION 1.10.1
+
+ENV NODE_MODULES_DIR /node_modules
+RUN mkdir $NODE_MODULES_DIR
+RUN chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_DIR
+
+RUN set -ex \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && rm /usr/local/bin/yarn \
+  && rm /usr/local/bin/yarnpkg \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
+
 RUN npm install npm -g
 RUN yarn global add node-gyp
 

--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,8 @@ build_8:
 build_8-alpine:
 	docker build -t local/articulate-node:8-alpine 8-alpine/
 
+build_10:
+	docker build -t local/articulate-node:10 10/
+
 build_10-alpine:
 	docker build -t local/articulate-node:10-alpine 10-alpine/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: build_6 build_8
+default: build_6 build_6-alpine build_8 build_8-alpine build_10-alpine
 
 build_6:
 	docker build -t local/articulate-node:6 6/


### PR DESCRIPTION
*  bumps yarn to `1.10.1`
*  exposes `NODE_MODULES_DIR` env var, set to `/node_modules` which can be used to `yarn install --modules-folder=$NODE_MODULES_DIR` (yes, I refuse to call it a folder).

yarn `1.10.0` includes a [bug fix](https://github.com/yarnpkg/yarn/pull/6275) for a bug preventing using a custom directory for `node_modules`.  This is a feature we've wanted to use because it will allow us to avoid tricky volume issues with the

```yaml
volumes:
   - '/service/node_modules'
```

hack, originally described [here](http://jdlm.info/articles/2016/03/06/lessons-building-node-app-docker.html#the-node_modules-volume-trick).  If we put `node_modules` outside of the `/service` path we can avoid the issues. 

### To test:

1.  pull this branch
1.  `make build_10-alpine`
1.  create the following `Dockerfile` in a clean directory, where the `FROM` line uses the sha from the `Successfully built 83ef3548012b` output of the previous command:
```
FROM 83ef3548012b
USER $SERVICE_USER

COPY --chown=service:service package.json yarn.lock $SERVICE_ROOT/
RUN yarn install --pure-lockfile --modules-folder=$NODE_MODULES_DIR && yarn cache clean

COPY --chown=service:service . $SERVICE_ROOT/
RUN rm -f $SERVICE_ROOT/.npmrc
```
1.  `npm init` using all defaults
1.  `yarn add leftpad`
1.  `docker build .`
1.  `docker run --rm e2c0384e7eaa ls /node_modules` where `e2c0384e7eaa` is the sha output from the previous command
1.  observe `leftpad` in the output
1.  repeat steps for `8-alpine`
1.  place a yarn squirrel in the comment box of this PR and click the **Comment** button