### PR TITLE
Add default security policy to Imagemagick

### DIFF
--- a/8-stretch-slim/Dockerfile
+++ b/8-stretch-slim/Dockerfile
@@ -35,6 +35,9 @@ RUN npm install npm -g
 # https://github.com/nodejs/node-gyp
 RUN yarn global add node-gyp
 
+# Add a strict security policy for Imagemagick (note: Imagemagick 7 is currently not available in Debian)
+COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
+
 # Our entrypoint will pull in our environment variables from Consul and Vault, and execute whatever command we provided the container.
 # See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/8-stretch-slim/imagemagick-policy.xml
+++ b/8-stretch-slim/imagemagick-policy.xml
@@ -1,0 +1,22 @@
+<!--
+  The policy.xml file is used by Imagemagick to define a security policy.
+
+  In our case we want to only allow the processing of safe image formats, and prevent any
+  use of Imagemagick's other functions like PDF or movie handling, since those are often implicated in security vulnerabilities.
+
+  Information on previously reported Imagemagick vulnerabilities and policy.xml based mitigations can be found here:
+  - https://www.openwall.com/lists/oss-security/2018/08/21/2
+  - https://imagetragick.com/
+  - https://www.kb.cert.org/vuls/id/332928/
+  - https://www.imagemagick.org/discourse-server/viewtopic.php?t=34617
+
+  This file should be placed in /etc/Imagemagick-6 (at least on our current Debian distribution).
+  We do this by way of a COPY command in the Dockerfile.
+  Once the file is in place, you can check if ImageMagick picks it up by issuing the command "convert -list policy" from a regular shell.
+-->
+<policymap>
+  <policy domain="delegate" rights="none" pattern="*" />
+  <policy domain="filter" rights="none" pattern="*" />
+  <policy domain="coder" rights="none" pattern="*" />
+  <policy domain="coder" rights="read|write" pattern="{GIF,JPEG,PNG,WEBP}" />
+</policymap>


### PR DESCRIPTION
One big reason why we install Imagemagick in the base image, is so that we can include a very strict policy file for it by default. 

This PR adds that policy file.