### PR TITLE
Editing imagemagick policy to work with our version

### DIFF
--- a/10-stretch-slim/imagemagick-policy.xml
+++ b/10-stretch-slim/imagemagick-policy.xml
@@ -12,11 +12,22 @@
 
   This file should be placed in /etc/Imagemagick-6 (at least on our current Debian distribution).
   We do this by way of a COPY command in the Dockerfile.
-  Once the file is in place, you can check if ImageMagick picks it up by issuing the command "convert -list policy" from a regular shell.
+
+  To verify the policy:
+  - use the command 'identify -list policy' to see if the policy file gets picked up
+  - use 'identify' on various image types to see if Imagemagick allows/blocks what you want it to
+  (Tip: use wget to pull in various files in your local container to test them out)
+
+  Note: most Imagemagick documentation shows a security policy with an aggregate pattern, like:
+  "<policy domain="coder" rights="read|write" pattern="{GIF,JPEG,PNG,WEBP}" />"
+  However, that only works from Imagemagick 6.9.7-9 upwards, and Debian 9 gives us only 6.9.7-4 at this time.
+  So here we have to specify them on seperate lines.
 -->
 <policymap>
   <policy domain="delegate" rights="none" pattern="*" />
   <policy domain="filter" rights="none" pattern="*" />
-  <policy domain="coder" rights="none" pattern="*" />
-  <policy domain="coder" rights="read|write" pattern="{GIF,JPEG,PNG,WEBP}" />
+  <policy domain="coder" rights="read|write" pattern="GIF" />
+  <policy domain="coder" rights="read|write" pattern="PNG" />
+  <policy domain="coder" rights="read|write" pattern="WEBP" />
+  <policy domain="coder" rights="read|write" pattern="JPEG" />
 </policymap>

--- a/8-stretch-slim/imagemagick-policy.xml
+++ b/8-stretch-slim/imagemagick-policy.xml
@@ -12,11 +12,22 @@
 
   This file should be placed in /etc/Imagemagick-6 (at least on our current Debian distribution).
   We do this by way of a COPY command in the Dockerfile.
-  Once the file is in place, you can check if ImageMagick picks it up by issuing the command "convert -list policy" from a regular shell.
+
+  To verify the policy:
+  - use the command 'identify -list policy' to see if the policy file gets picked up
+  - use 'identify' on various image types to see if Imagemagick allows/blocks what you want it to
+  (Tip: use wget to pull in various files in your local container to test them out)
+
+  Note: most Imagemagick documentation shows a security policy with an aggregate pattern, like:
+  "<policy domain="coder" rights="read|write" pattern="{GIF,JPEG,PNG,WEBP}" />"
+  However, that only works from Imagemagick 6.9.7-9 upwards, and Debian 9 gives us only 6.9.7-4 at this time.
+  So here we have to specify them on seperate lines.
 -->
 <policymap>
   <policy domain="delegate" rights="none" pattern="*" />
   <policy domain="filter" rights="none" pattern="*" />
-  <policy domain="coder" rights="none" pattern="*" />
-  <policy domain="coder" rights="read|write" pattern="{GIF,JPEG,PNG,WEBP}" />
+  <policy domain="coder" rights="read|write" pattern="GIF" />
+  <policy domain="coder" rights="read|write" pattern="PNG" />
+  <policy domain="coder" rights="read|write" pattern="WEBP" />
+  <policy domain="coder" rights="read|write" pattern="JPEG" />
 </policymap>


### PR DESCRIPTION
We've discovered the hard way today that specifying whitelisted image formats in one line doesn't work with the version of Imagemagick that Debian Stretch gives us at this time.

This PR changes the policy to actually work, and adds notes on what we learned today.