### PR TITLE
Remove Python 2

### DIFF
--- a/10-alpine/Dockerfile
+++ b/10-alpine/Dockerfile
@@ -3,8 +3,7 @@ FROM node:10-alpine
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-# Note: we install python 2 because node-gyp v5 does not support python 3, & we want child images to continue to be able to build native addons
-RUN apk add --no-cache bash make gcc g++ binutils jq sudo unzip python2
+RUN apk add --no-cache bash make gcc g++ binutils jq sudo unzip
 
 RUN apk upgrade --no-cache binutils jq sudo unzip
 

--- a/10-stretch-slim/Dockerfile
+++ b/10-stretch-slim/Dockerfile
@@ -6,10 +6,9 @@ FROM node:10-stretch-slim
 # Run apt-get quietly (-qq) and say yes to prompts (-y)
 # See best practices for apt-get in Docker at https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
 # Note: we install Imagemagick in our base image so we can keep it updated in one place, and so we can add a strict security policy by default (see further down)
-# Note: we install python 2 because node-gyp v5 does not support python 3, & we want child images to continue to be able to build native addons
 RUN apt-get update -qq \
     && apt-get upgrade -y \
-    && apt-get install -y build-essential imagemagick python2.7 \
+    && apt-get install -y build-essential imagemagick \
     && apt-get upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -26,7 +25,6 @@ RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV NODE_MODULES_PATH /node_modules
-ENV PYTHON /usr/bin/python2.7
 
 # Create our service group and user, and set the directory where we'll work from going forward
 RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER

--- a/6-alpine/Dockerfile
+++ b/6-alpine/Dockerfile
@@ -4,8 +4,7 @@ ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV NPM_VER 6.1.0
 
-# Note: we install python 2 because node-gyp v5 does not support python 3, & we want child images to continue to be able to build native addons
-RUN apk add --no-cache bash make gcc g++ binutils jq sudo unzip tar curl python2
+RUN apk add --no-cache bash make gcc g++ binutils jq sudo unzip tar curl
 
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh

--- a/8-alpine/Dockerfile
+++ b/8-alpine/Dockerfile
@@ -3,8 +3,7 @@ FROM node:8-alpine
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 
-# Note: we install python 2 because node-gyp v5 does not support python 3, & we want child images to continue to be able to build native addons
-RUN apk add --no-cache bash make gcc g++ binutils jq sudo unzip python2
+RUN apk add --no-cache bash make gcc g++ binutils jq sudo unzip 
 
 RUN apk upgrade --no-cache binutils jq sudo unzip
 

--- a/8-stretch-slim/Dockerfile
+++ b/8-stretch-slim/Dockerfile
@@ -6,10 +6,9 @@ FROM node:8-stretch-slim
 # Run apt-get quietly (-qq) and say yes to prompts (-y)
 # See best practices for apt-get in Docker at https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
 # Note: we install Imagemagick in our base image so we can keep it updated in one place, and so we can add a strict security policy by default (see further down)
-# Note: we install python 2 because node-gyp v5 does not support python 3, & we want child images to continue to be able to build native addons
 RUN apt-get update -qq \
     && apt-get upgrade -y \
-    && apt-get install -y build-essential imagemagick python2.7 \
+    && apt-get install -y build-essential imagemagick \
     && apt-get upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -26,7 +25,6 @@ RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service
 ENV NODE_MODULES_PATH /node_modules
-ENV PYTHON /usr/bin/python2.7
 
 # Create our service group and user, and set the directory where we'll work from going forward
 RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER


### PR DESCRIPTION
`node-gyp` 6 supports python 3. This removes python 2 from the builds by reverting https://github.com/articulate/docker-articulate-node/pull/54 as promised. I tested each image, & it seems no additional action is needed to get `node-gyp` to work.

Note, the default python version for stretch (not stretch-slim) is still python 2. Builds may still display EOL warnings but will continue to work.