### PR TITLE
Add node 10 lambda image

### DIFF
--- a/10-lambda/Dockerfile
+++ b/10-lambda/Dockerfile
@@ -1,0 +1,26 @@
+FROM lambci/lambda:build-nodejs10.x
+
+ENV AWS_DEFAULT_REGION us-east-1
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+ENV SHELL bash
+
+ENV AWS_SDK_VERSION 2.290.0
+ENV YARN_VERSION 1.17.3
+
+RUN npm i -g \
+  aws-sdk@$AWS_SDK_VERSION \
+  node-gyp \
+  yarn@$YARN_VERSION
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
+WORKDIR $SERVICE_ROOT
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+RUN chmod a+rx /wait-for-it.sh
+
+COPY entrypoint-lambda.sh /
+ENTRYPOINT ["/entrypoint-lambda.sh"]

--- a/10-lambda/entrypoint-lambda.sh
+++ b/10-lambda/entrypoint-lambda.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+npm link aws-sdk
+/entrypoint.sh "$@"

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ build_8-stretch-slim:
 build_10-alpine:
 	docker build -t local/articulate-node:10-alpine 10-alpine/
 
+build_10-lambda:
+	docker build -t local/articulate-node:10-lambda 10-lambda/
+
 build_10-stretch-slim:
 	docker build -t local/articulate-node:10-stretch-slim 10-stretch-slim/
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ default: build_6 build_8
 
 alpine: build_6-alpine build_8-alpine build_10-alpine
 
-lambda: build_8-lambda
+lambda: build_8-lambda build_10-lambda
 
 stretch-slim: build_8-stretch-slim build_10-stretch-slim build_12-stretch-slim
 


### PR DESCRIPTION
With Node 8's EOL only a few months away, create a new base image for Lambda's Node 10 runtime.