### PR TITLE
Add lambda node 14 image

### DIFF
--- a/14-lambda/Dockerfile
+++ b/14-lambda/Dockerfile
@@ -1,0 +1,27 @@
+FROM amazon/aws-lambda-nodejs:14
+
+ENV AWS_DEFAULT_REGION us-east-1
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+ENV SHELL bash
+
+ENV AWS_SDK_VERSION 2.585.0
+ENV YARN_VERSION 1.19.2
+
+RUN npm i -g \
+  aws-sdk@$AWS_SDK_VERSION \
+  node-gyp \
+  yarn@$YARN_VERSION
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+RUN yum -y install shadow-utils && yum clean all
+RUN /usr/sbin/groupadd $SERVICE_USER && /usr/sbin/useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
+WORKDIR $SERVICE_ROOT
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+RUN chmod a+rx /wait-for-it.sh
+
+COPY entrypoint-lambda.sh /
+ENTRYPOINT ["/entrypoint-lambda.sh"]

--- a/14-lambda/entrypoint-lambda.sh
+++ b/14-lambda/entrypoint-lambda.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+npm link aws-sdk
+/entrypoint.sh "$@"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: lambda stretch-slim
 
-lambda: build_10-lambda build_12-lambda
+lambda: build_10-lambda build_12-lambda build_14-lambda
 
 stretch-slim: build_10-stretch-slim build_12-stretch-slim build_14-stretch-slim
 
@@ -9,6 +9,9 @@ build_10-lambda:
 
 build_12-lambda:
 	docker build -t local/articulate-node:12-lambda 12-lambda/
+
+build_14-lambda:
+	docker build -t local/articulate-node:14-lambda 14-lambda/
 
 build_10-stretch-slim:
 	docker build -t local/articulate-node:10-stretch-slim 10-stretch-slim/


### PR DESCRIPTION
Adds `articulate/articulate-node:14-lambda` image.

Looks like lambci is more or less deprecated at this point https://github.com/lambci/docker-lambda/issues/329. So i'm going with the newer official amazon base image.

This is working locally. I'm not too sure how to get it on dockerhub.