### PR TITLE
Adding node-12-buster-slim image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
           - "10-stretch-slim"
           - "12-stretch-slim"
           - "14-stretch-slim"
+          - "12-buster-slim"
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
           - "12-stretch-slim"
           - "14-stretch-slim"
           - "12-buster-slim"
+          - "14-buster-slim"
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/12-buster-slim/Dockerfile
+++ b/12-buster-slim/Dockerfile
@@ -1,0 +1,38 @@
+FROM node:12-buster-slim
+
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+ENV NODE_MODULES_PATH /node_modules
+ENV PATH $PATH:$NODE_MODULES_PATH/.bin
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+
+RUN apt-get update -qq \
+        && apt-get upgrade -y \
+        && apt-get install -y --no-install-recommends \
+            build-essential imagemagick \
+        && apt-get upgrade -y \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/* \
+    && bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh \
+    && chmod a+rx /wait-for-it.sh \
+    # Create our own user and remove the node user
+    && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
+    && userdel -r node \
+    # Install the latest version of npm
+    && npm install -g npm \
+    # Make node-gyp globally available (used for compiling native modules for Node.js)
+    && yarn global add node-gyp \
+    # Create the node_modules directory, make it owned by service user
+    && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH
+
+# Add a strict security policy for Imagemagick (note: Imagemagick 7 is currently not available in Debian)
+COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
+
+WORKDIR $SERVICE_ROOT
+
+# Our entrypoint will pull in our environment variables from Consul and Vault,
+# and execute whatever command we provided the container.
+# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/12-buster-slim/imagemagick-policy.xml
+++ b/12-buster-slim/imagemagick-policy.xml
@@ -1,0 +1,32 @@
+<!--
+  The policy.xml file is used by Imagemagick to define a security policy.
+
+  In our case we want to only allow the processing of safe image formats, and prevent any
+  use of Imagemagick's other functions like PDF or movie handling, since those are often implicated in security vulnerabilities.
+
+  Information on previously reported Imagemagick vulnerabilities and policy.xml based mitigations can be found here:
+  - https://www.openwall.com/lists/oss-security/2018/08/21/2
+  - https://imagetragick.com/
+  - https://www.kb.cert.org/vuls/id/332928/
+  - https://www.imagemagick.org/discourse-server/viewtopic.php?t=34617
+
+  This file should be placed in /etc/Imagemagick-6 (at least on our current Debian distribution).
+  We do this by way of a COPY command in the Dockerfile.
+
+  To verify the policy:
+  - use the command 'identify -list policy' to see if the policy file gets picked up
+  - use 'identify' on various image types to see if Imagemagick allows/blocks what you want it to
+  (Tip: use wget to pull in various files in your local container to test them out)
+
+  Note: most Imagemagick documentation shows a security policy with an aggregate pattern, like {GIF,JPEG,PNG,WEBP}
+  However, that only works from Imagemagick 6.9.7-9 upwards, and Debian 9 gives us only 6.9.7-4 at this time.
+  So here we have to specify them on seperate lines.
+-->
+<policymap>
+  <policy domain="delegate" rights="none" pattern="*" />
+  <policy domain="filter" rights="none" pattern="*" />
+  <policy domain="coder" rights="read|write" pattern="GIF" />
+  <policy domain="coder" rights="read|write" pattern="PNG" />
+  <policy domain="coder" rights="read|write" pattern="WEBP" />
+  <policy domain="coder" rights="read|write" pattern="JPEG" />
+</policymap>

--- a/14-buster-slim/Dockerfile
+++ b/14-buster-slim/Dockerfile
@@ -1,0 +1,38 @@
+FROM node:14-buster-slim
+
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+ENV NODE_MODULES_PATH /node_modules
+ENV PATH $PATH:$NODE_MODULES_PATH/.bin
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+
+RUN apt-get update -qq \
+        && apt-get upgrade -y \
+        && apt-get install -y --no-install-recommends \
+            build-essential imagemagick \
+        && apt-get upgrade -y \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/* \
+    && bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh \
+    && chmod a+rx /wait-for-it.sh \
+    # Create our own user and remove the node user
+    && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
+    && userdel -r node \
+    # Install the latest version of npm
+    && npm install -g npm \
+    # Make node-gyp globally available (used for compiling native modules for Node.js)
+    && yarn global add node-gyp \
+    # Create the node_modules directory, make it owned by service user
+    && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH
+
+# Add a strict security policy for Imagemagick (note: Imagemagick 7 is currently not available in Debian)
+COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
+
+WORKDIR $SERVICE_ROOT
+
+# Our entrypoint will pull in our environment variables from Consul and Vault,
+# and execute whatever command we provided the container.
+# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/14-buster-slim/imagemagick-policy.xml
+++ b/14-buster-slim/imagemagick-policy.xml
@@ -1,0 +1,32 @@
+<!--
+  The policy.xml file is used by Imagemagick to define a security policy.
+
+  In our case we want to only allow the processing of safe image formats, and prevent any
+  use of Imagemagick's other functions like PDF or movie handling, since those are often implicated in security vulnerabilities.
+
+  Information on previously reported Imagemagick vulnerabilities and policy.xml based mitigations can be found here:
+  - https://www.openwall.com/lists/oss-security/2018/08/21/2
+  - https://imagetragick.com/
+  - https://www.kb.cert.org/vuls/id/332928/
+  - https://www.imagemagick.org/discourse-server/viewtopic.php?t=34617
+
+  This file should be placed in /etc/Imagemagick-6 (at least on our current Debian distribution).
+  We do this by way of a COPY command in the Dockerfile.
+
+  To verify the policy:
+  - use the command 'identify -list policy' to see if the policy file gets picked up
+  - use 'identify' on various image types to see if Imagemagick allows/blocks what you want it to
+  (Tip: use wget to pull in various files in your local container to test them out)
+
+  Note: most Imagemagick documentation shows a security policy with an aggregate pattern, like {GIF,JPEG,PNG,WEBP}
+  However, that only works from Imagemagick 6.9.7-9 upwards, and Debian 9 gives us only 6.9.7-4 at this time.
+  So here we have to specify them on seperate lines.
+-->
+<policymap>
+  <policy domain="delegate" rights="none" pattern="*" />
+  <policy domain="filter" rights="none" pattern="*" />
+  <policy domain="coder" rights="read|write" pattern="GIF" />
+  <policy domain="coder" rights="read|write" pattern="PNG" />
+  <policy domain="coder" rights="read|write" pattern="WEBP" />
+  <policy domain="coder" rights="read|write" pattern="JPEG" />
+</policymap>

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ lambda: build_10-lambda build_12-lambda build_14-lambda
 
 stretch-slim: build_10-stretch-slim build_12-stretch-slim build_14-stretch-slim
 
-buster-slim: build_12-buster-slim
+buster-slim: build_12-buster-slim build_14-buster-slim
 
 .PHONY: all lambda stretch-slim buster-slim
 
@@ -35,3 +35,7 @@ buster-slim: build_12-buster-slim
 12-buster-slim:
 	docker build -t local/articulate-node:12-buster-slim 12-buster-slim
 .PHONY: 12-buster-slim
+
+14-buster-slim:
+	docker build -t local/articulate-node:14-buster-slim 14-buster-slim
+.PHONY: 14-buster-slim

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,7 @@ stretch-slim: build_10-stretch-slim build_12-stretch-slim build_14-stretch-slim
 14-stretch-slim:
 	docker build -t local/articulate-node:14-stretch-slim 14-stretch-slim
 .PHONY: 14-stretch-slim
+
+12-buster-slim:
+	docker build -t local/articulate-node:12-buster-slim 12-buster-slim
+.PHONY: 12-buster-slim

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ lambda: build_10-lambda build_12-lambda build_14-lambda
 
 stretch-slim: build_10-stretch-slim build_12-stretch-slim build_14-stretch-slim
 
-.PHONY: all lambda stretch-slim
+buster-slim: build_12-buster-slim
+
+.PHONY: all lambda stretch-slim buster-slim
 
 10-lambda:
 	docker build -t local/articulate-node:10-lambda 10-lambda

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: lambda stretch-slim
+all: lambda stretch-slim buster-slim
 
 lambda: build_10-lambda build_12-lambda build_14-lambda
 


### PR DESCRIPTION
Adds `articulate/articulate-node:12-buster-slim` image.

This PR adds the ☝️ image so rise-api can update the `argon2` NPM package. Currently `argon2` is used within the customer API and will not work on stretch images. 

```bash
docker run -it node:12-stretch-slim bash
root@40ad307daa8a:/# npm install argon2
root@40ad307daa8a:/# node
Welcome to Node.js v12.22.6.
Type ".help" for more information.
> require('argon2')
Uncaught:
Error: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.25' not found (required by /node_modules/argon2/lib/binding/napi-v3/argon2.node)
```
buster is newer then stretch https://wiki.debian.org/LTS