### PR TITLE
fix(node-gyp): install python for node-gyp

### DIFF
--- a/12-buster-slim/Dockerfile
+++ b/12-buster-slim/Dockerfile
@@ -11,7 +11,7 @@ ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstra
 RUN apt-get update -qq \
         && apt-get upgrade -y \
         && apt-get install -y --no-install-recommends \
-            build-essential imagemagick \
+            build-essential python3 imagemagick \
         && apt-get upgrade -y \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/* \
@@ -21,9 +21,7 @@ RUN apt-get update -qq \
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
     && userdel -r node \
     # Install the latest version of npm
-    && npm install -g npm \
-    # Make node-gyp globally available (used for compiling native modules for Node.js)
-    && yarn global add node-gyp \
+    && npm install -g npm@latest \
     # Create the node_modules directory, make it owned by service user
     && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH
 

--- a/12-lambda/Dockerfile
+++ b/12-lambda/Dockerfile
@@ -6,21 +6,20 @@ ENV SERVICE_USER service
 ENV SHELL bash
 
 ENV AWS_SDK_VERSION 2.585.0
-ENV YARN_VERSION 1.19.2
+ENV YARN_VERSION 1.22.15
 
 COPY entrypoint-lambda.sh /
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
 
-RUN npm i -g \
+RUN npm install -g \
         aws-sdk@$AWS_SDK_VERSION \
-        node-gyp \
+        npm@7 \
         yarn@$YARN_VERSION \
     && bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh \
     && chmod a+rx /wait-for-it.sh \
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
 
 WORKDIR $SERVICE_ROOT
-
 
 ENTRYPOINT ["/entrypoint-lambda.sh"]

--- a/12-stretch-slim/Dockerfile
+++ b/12-stretch-slim/Dockerfile
@@ -11,7 +11,7 @@ ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstra
 RUN apt-get update -qq \
         && apt-get upgrade -y \
         && apt-get install -y --no-install-recommends \
-            build-essential imagemagick \
+            build-essential python imagemagick \
         && apt-get upgrade -y \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/* \
@@ -20,10 +20,8 @@ RUN apt-get update -qq \
     # Create our own user and remove the node user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
     && userdel -r node \
-    # Install the latest version of npm
-    && npm install -g npm \
-    # Make node-gyp globally available (used for compiling native modules for Node.js)
-    && yarn global add node-gyp \
+    # Install the latest version of npm that has a node-gyp which works with Python 2.7
+    && npm install -g npm@7 \
     # Create the node_modules directory, make it owned by service user
     && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH
 

--- a/14-buster-slim/Dockerfile
+++ b/14-buster-slim/Dockerfile
@@ -11,7 +11,7 @@ ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstra
 RUN apt-get update -qq \
         && apt-get upgrade -y \
         && apt-get install -y --no-install-recommends \
-            build-essential imagemagick \
+            build-essential python3 imagemagick \
         && apt-get upgrade -y \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/* \
@@ -21,9 +21,7 @@ RUN apt-get update -qq \
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
     && userdel -r node \
     # Install the latest version of npm
-    && npm install -g npm \
-    # Make node-gyp globally available (used for compiling native modules for Node.js)
-    && yarn global add node-gyp \
+    && npm install -g npm@latest \
     # Create the node_modules directory, make it owned by service user
     && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH
 

--- a/14-lambda/Dockerfile
+++ b/14-lambda/Dockerfile
@@ -6,16 +6,16 @@ ENV SERVICE_USER service
 ENV SHELL bash
 
 ENV AWS_SDK_VERSION 2.585.0
-ENV YARN_VERSION 1.19.2
+ENV YARN_VERSION 1.22.15
 
 COPY entrypoint-lambda.sh /
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
 
 RUN yum -y install shadow-utils make zip && yum clean all \
-    && npm i -g \
+    && npm install -g \
         aws-sdk@$AWS_SDK_VERSION \
-        node-gyp \
+        node@7 \
         yarn@$YARN_VERSION \
     && bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh \
     && chmod a+rx /wait-for-it.sh \

--- a/14-stretch-slim/Dockerfile
+++ b/14-stretch-slim/Dockerfile
@@ -12,7 +12,7 @@ ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstra
 RUN apt-get update -qq \
         && apt-get upgrade -y \
         && apt-get install -y --no-install-recommends \
-            build-essential imagemagick \
+            build-essential python imagemagick \
         && apt-get upgrade -y \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/* \
@@ -21,10 +21,8 @@ RUN apt-get update -qq \
     # Create our own user and remove the node user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
     && userdel -r node \
-    # Install the latest version of npm
-    && npm install -g npm \
-    # Make node-gyp globally available (used for compiling native modules for Node.js)
-    && yarn global add node-gyp \
+    # Install the latest version of npm that has a node-gyp which works with Python 2.7
+    && npm install -g npm@7 \
     # Create the node_modules directory, make it owned by service user
     && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH
 

--- a/16-buster-slim/Dockerfile
+++ b/16-buster-slim/Dockerfile
@@ -11,7 +11,7 @@ ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstra
 RUN apt-get update -qq \
         && apt-get upgrade -y \
         && apt-get install -y --no-install-recommends \
-            build-essential imagemagick \
+            build-essential python3 imagemagick \
         && apt-get upgrade -y \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/* \
@@ -21,9 +21,7 @@ RUN apt-get update -qq \
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
     && userdel -r node \
     # Install the latest version of npm
-    && npm install -g npm \
-    # Make node-gyp globally available (used for compiling native modules for Node.js)
-    && yarn global add node-gyp \
+    && npm install -g npm@latest \
     # Create the node_modules directory, make it owned by service user
     && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH
 

--- a/16-stretch-slim/Dockerfile
+++ b/16-stretch-slim/Dockerfile
@@ -11,7 +11,7 @@ ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstra
 RUN apt-get update -qq \
         && apt-get upgrade -y \
         && apt-get install -y --no-install-recommends \
-            build-essential imagemagick \
+            build-essential python imagemagick \
         && apt-get upgrade -y \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/* \
@@ -20,10 +20,8 @@ RUN apt-get update -qq \
     # Create our own user and remove the node user
     && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
     && userdel -r node \
-    # Install the latest version of npm
-    && npm install -g npm \
-    # Make node-gyp globally available (used for compiling native modules for Node.js)
-    && yarn global add node-gyp \
+    # Install the latest version of npm that has a node-gyp which works with Python 2.7
+    && npm install -g npm@7 \
     # Create the node_modules directory, make it owned by service user
     && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH
 


### PR DESCRIPTION
node-gyp needs Python to build packages. Python was removed back in June when we upgraded to awscliv2.

Removes the direct install of node-gyp. This was probably a copy-paste from when npm didn't come bundled with node-gyp. Even if you install node-gyp, it still uses the bundled version.

The latest version of node-gyp, which is shipped with the latest npm, requires Python 3.6 or later. In Stretch, the latest version of Python in apt is 3.5. To fix this install npm@7, which still works with Python 2.7.

In Buster install python3 (3.7), which works with the latest node-gyp.

In Lambda, install npm@7 since those images contain Python 2.7. Also bump the Yarn version to latest classic.

In images that are using npm@7, nothing should break. npm@8 didn't have any major changes (just droped Node 10 support). And we tend to use Yarn anyway, which won't change at all.