### PR TITLE
fix(lambda): upgrade npm before installing any packages

### DIFF
--- a/12-lambda/Dockerfile
+++ b/12-lambda/Dockerfile
@@ -12,9 +12,9 @@ COPY entrypoint-lambda.sh /
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
 
-RUN npm install -g \
+RUN npm install -g npm@7 \
+    && npm install -g \
         aws-sdk@$AWS_SDK_VERSION \
-        npm@7 \
         yarn@$YARN_VERSION \
     && bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh \
     && chmod a+rx /wait-for-it.sh \

--- a/14-lambda/Dockerfile
+++ b/14-lambda/Dockerfile
@@ -13,9 +13,9 @@ ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstra
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
 
 RUN yum -y install shadow-utils make zip && yum clean all \
+    && npm install -g node@7 \
     && npm install -g \
         aws-sdk@$AWS_SDK_VERSION \
-        node@7 \
         yarn@$YARN_VERSION \
     && bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh \
     && chmod a+rx /wait-for-it.sh \


### PR DESCRIPTION
Installing npm at the same time as yarn causes issues due to not being able to find npm. Move this to a different step.