### PR TITLE
Add 16-bullseye-slim image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule: # Run everyday
-    - cron: "0 0 * * *"
+    - cron: '0 0 * * *'
 
 jobs:
   build:
@@ -22,6 +22,7 @@ jobs:
           - 14-buster-slim
           - 16-stretch-slim
           - 16-buster-slim
+          - 16-bullseye-slim
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,7 @@ jobs:
           - 14-buster-slim
           - 16-stretch-slim
           - 16-buster-slim
+          - 16-bullseye-slim
     steps:
       - uses: actions/checkout@v2
       - uses: hadolint/hadolint-action@v1.6.0

--- a/16-bullseye-slim/Dockerfile
+++ b/16-bullseye-slim/Dockerfile
@@ -1,0 +1,36 @@
+FROM node:16-bullseye-slim
+
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+ENV NODE_MODULES_PATH /node_modules
+ENV PATH $PATH:$NODE_MODULES_PATH/.bin
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+
+RUN apt-get update -qq \
+        && apt-get upgrade -y \
+        && apt-get install -y --no-install-recommends \
+            build-essential python3 imagemagick \
+        && apt-get upgrade -y \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/* \
+    && bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh \
+    && chmod a+rx /wait-for-it.sh \
+    # Create our own user and remove the node user
+    && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
+    && userdel -r node \
+    # Install the latest version of npm
+    && npm install -g npm@latest \
+    # Create the node_modules directory, make it owned by service user
+    && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH
+
+# Add a strict security policy for Imagemagick (note: Imagemagick 7 is currently not available in Debian)
+COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
+
+WORKDIR $SERVICE_ROOT
+
+# Our entrypoint will pull in our environment variables from Consul and Vault,
+# and execute whatever command we provided the container.
+# See https://github.com/articulate/docker-consul-template-bootstrap/blob/master/entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/16-bullseye-slim/imagemagick-policy.xml
+++ b/16-bullseye-slim/imagemagick-policy.xml
@@ -1,0 +1,32 @@
+<!--
+  The policy.xml file is used by Imagemagick to define a security policy.
+
+  In our case we want to only allow the processing of safe image formats, and prevent any
+  use of Imagemagick's other functions like PDF or movie handling, since those are often implicated in security vulnerabilities.
+
+  Information on previously reported Imagemagick vulnerabilities and policy.xml based mitigations can be found here:
+  - https://www.openwall.com/lists/oss-security/2018/08/21/2
+  - https://imagetragick.com/
+  - https://www.kb.cert.org/vuls/id/332928/
+  - https://www.imagemagick.org/discourse-server/viewtopic.php?t=34617
+
+  This file should be placed in /etc/Imagemagick-6 (at least on our current Debian distribution).
+  We do this by way of a COPY command in the Dockerfile.
+
+  To verify the policy:
+  - use the command 'identify -list policy' to see if the policy file gets picked up
+  - use 'identify' on various image types to see if Imagemagick allows/blocks what you want it to
+  (Tip: use wget to pull in various files in your local container to test them out)
+
+  Note: most Imagemagick documentation shows a security policy with an aggregate pattern, like {GIF,JPEG,PNG,WEBP}
+  However, that only works from Imagemagick 6.9.7-9 upwards, and Debian 9 gives us only 6.9.7-4 at this time.
+  So here we have to specify them on seperate lines.
+-->
+<policymap>
+  <policy domain="delegate" rights="none" pattern="*" />
+  <policy domain="filter" rights="none" pattern="*" />
+  <policy domain="coder" rights="read|write" pattern="GIF" />
+  <policy domain="coder" rights="read|write" pattern="PNG" />
+  <policy domain="coder" rights="read|write" pattern="WEBP" />
+  <policy domain="coder" rights="read|write" pattern="JPEG" />
+</policymap>

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,7 @@ buster-slim: 12-buster-slim 14-buster-slim 16-buster-slim
 16-buster-slim:
 	docker build -t local/articulate-node:16-buster-slim 16-buster-slim
 .PHONY: 16-buster-slim
+
+16-bullseye-slim:
+	docker build -t local/articulate-node:16-bullseye-slim 16-bullseye-slim
+.PHONY: 16-bullseye-slim

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
-all: lambda stretch-slim buster-slim
+all: lambda stretch-slim buster-slim bullseye-slim
 
 lambda: 12-lambda 14-lambda
 
 stretch-slim: 12-stretch-slim 14-stretch-slim 16-stretch-slim
 
 buster-slim: 12-buster-slim 14-buster-slim 16-buster-slim
+
+bullseye-slim: 16-bullseye-slim
 
 .PHONY: all lambda stretch-slim buster-slim
 


### PR DESCRIPTION
Bullseye-slim is needed for our https://github.com/articulate/docker-articulate-node-images repo which in turn is needed for https://github.com/articulate/images.

The root issue is M1 macs require glibc 2.29+ in order to run images locally (due to dependency on sharp)

Related issue `https://github.com/articulate/rise-authoring/issues/1168`

## New Image Checklist

If you're adding a new image, make sure you have done the following.

* [x] Added to lint workflow matrix (`.github/workflows/lint.yml`)
* [x] Added to build workflow matrix (`.github/workflows/build.yml`)
* [x] Added to Makefile (`Makefile`)
