### PR TITLE
ci(build): run on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build
 on:
   pull_request:
   push:
+    branches:
+      - main
   schedule:
     # Run everyday
     - cron: '0 0 * * *'
@@ -11,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         image:
           - 12-lambda
@@ -36,7 +38,7 @@ jobs:
       - uses: docker/build-push-action@v3
         with:
           context: ${{ matrix.image }}
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: articulate/articulate-node:${{ matrix.image }}
           platforms: linux/amd64,linux/arm64/v8
           cache-from: type=registry,ref=articulate/articulate-node:${{ matrix.image }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,8 @@
 name: Build
 
 on:
+  pull_request:
   push:
-    branches:
-      - main
   schedule:
     # Run everyday
     - cron: '0 0 * * *'
@@ -12,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         image:
           - 12-lambda
@@ -37,7 +36,7 @@ jobs:
       - uses: docker/build-push-action@v3
         with:
           context: ${{ matrix.image }}
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: articulate/articulate-node:${{ matrix.image }}
           platforms: linux/amd64,linux/arm64/v8
           cache-from: type=registry,ref=articulate/articulate-node:${{ matrix.image }}


### PR DESCRIPTION
This updates the `build.yml` file to run on PRs and pushes to them while also attempting to only publish when we are in the context of the `main` branch.

Borne out of https://github.com/articulate/docker-articulate-node/pull/86

## New Image Checklist

If you're adding a new image, make sure you have done the following.

* [ ] Added to lint workflow matrix (`.github/workflows/lint.yml`)
* [ ] Added to build workflow matrix (`.github/workflows/build.yml`)
* [ ] Added to Makefile (`Makefile`)
