### PR TITLE
feat: add retry CLI tool

### DIFF
--- a/16-bullseye-slim/Dockerfile
+++ b/16-bullseye-slim/Dockerfile
@@ -11,7 +11,7 @@ ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstra
 RUN apt-get update -qq \
         && apt-get upgrade -y \
         && apt-get install -y --no-install-recommends \
-            build-essential python3 imagemagick \
+            build-essential python3 imagemagick retry \
         && apt-get upgrade -y \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/* \

--- a/18-bullseye-slim/Dockerfile
+++ b/18-bullseye-slim/Dockerfile
@@ -11,7 +11,7 @@ ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstra
 RUN apt-get update -qq \
         && apt-get upgrade -y \
         && apt-get install -y --no-install-recommends \
-            build-essential python3 imagemagick \
+            build-essential python3 imagemagick retry \
         && apt-get upgrade -y \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
This adds the [`retry`](https://github.com/minfrin/retry/tree/main) CLI tool to the images that have the package so that dependent images can do things like this:

```Dockerfile
RUN retry --times 4 -- yarn install --frozen-lockfile && yarn cache clean
```

It looks like the package is only available on `bullseye` for us: https://packages.debian.org/search?keywords=retry

If we were use our own script, we would have to copy and paste it in every folder, which isn't the end of the world. If we were to `ADD` a script from a URL, we would need to change the USER to root to chmod it to an executable.

This was borne out of https://github.com/articulate/docker-articulate-node/pull/86.

## To test

1. Check out this branch
2. Run `make`
3. Go to your local copy of https://github.com/articulate/rise-frontend/
4. Run `docker compose down`
5. Run `docker images`, find the image ID of `rise-frontend_app` or whatever if you already have that and grab the image ID
6. Run `docker rmi that-id` then `docker volume prune` then `docker image prune`
7. Go to the `Dockerfile`
8. Change `FROM articulate/articulate-node:18-bullseye-slim` to `FROM local/articulate-node:18-bullseye-slim`
9. Run `docker compose build --no-cache`
10. Run `art -on 360-stage docker-compose up` and make sure that build completes

## New Image Checklist

If you're adding a new image, make sure you have done the following.

* [ ] Added to lint workflow matrix (`.github/workflows/lint.yml`)
* [ ] Added to build workflow matrix (`.github/workflows/build.yml`)
* [ ] Added to Makefile (`Makefile`)
