### PR TITLE
feat: add 18-lambda image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
           - 16-buster-slim
           - 16-bullseye-slim
           - 18-bullseye-slim
+          - 18-lambda
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,7 @@ jobs:
           - 16-buster-slim
           - 16-bullseye-slim
           - 18-bullseye-slim
+          - 18-lambda
     steps:
       - uses: actions/checkout@v3
       - uses: hadolint/hadolint-action@4b5806eb9c6bee4954fc0e0cc3ad6175fc9782c1 # pin@v3.0.0

--- a/18-lambda/Dockerfile
+++ b/18-lambda/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1
+FROM amazon/aws-lambda-nodejs:18
+
+ENV AWS_DEFAULT_REGION us-east-1
+
+ARG TARGETARCH
+ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+
+RUN yum -y install make zip \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
+ENTRYPOINT [ "/entrypoint" ]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: lambda stretch-slim buster-slim bullseye-slim
 
-lambda: 12-lambda 14-lambda 16-lambda
+lambda: 12-lambda 14-lambda 16-lambda 18-lambda
 
 stretch-slim: 12-stretch-slim 14-stretch-slim 16-stretch-slim
 
@@ -53,3 +53,7 @@ bullseye-slim: 16-bullseye-slim 18-bullseye-slim
 18-bullseye-slim:
 	docker build -t local/articulate-node:18-bullseye-slim 18-bullseye-slim
 .PHONY: 18-bullseye-slim
+
+18-lambda:
+	docker build -t local/articulate-node:18-lambda 18-lambda
+.PHONY: 18-lambda

--- a/README.md
+++ b/README.md
@@ -2,15 +2,38 @@
 
 Base Node.js image that contains common dependencies used in our organization.
 
+```dockerfile
+FROM articulate/articulate-node:<tag>
+```
+
+## Tags
+
+> 🌟 recommended image
+
+* __18-bullseye-slim__ 🌟
+* __18-lambda__ 🌟
+* __16-bullseye-slim__ 🌟
+* __16-lambda__ 🌟
+* 16-buster-slim
+* 16-stretch-slim
+* 14-buster-slim
+* 14-stretch-slim
+* 14-lambda
+* 12-buster-slim
+* 12-stretch-slim
+* 12-lambda
+
 ## Adding an image
 
 1. Create directory for image
-2. Add Dockerfile and any related policies to directory
-3. Update the Makefile: [Example](https://github.com/articulate/docker-articulate-node/pull/70/commits/3d58f80b8be0da9edcd1e38d5ffe600186199ac9#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R33)
-4. Add the image to the Github Action workflow [Matrix](https://github.com/articulate/docker-articulate-node/blob/809aec98a0d99cdcb214662725a32e56b76dfb50/.github/workflows/build.yml#L16) - this will build the image and add to DockerHub.
+2. Add Dockerfile and any related policies to the directory
+3. Add a Makefile [target](https://github.com/articulate/docker-articulate-node/blob/02fe1df76dddcc5f6482e954cf3ff0ca814ab4ab/Makefile#L53),
+  including any [categories](https://github.com/articulate/docker-articulate-node/blob/02fe1df76dddcc5f6482e954cf3ff0ca814ab4ab/Makefile#L9).
+4. Add the image to the [build](https://github.com/articulate/docker-articulate-node/blob/02fe1df76dddcc5f6482e954cf3ff0ca814ab4ab/.github/workflows/build.yml#L26)
+  and [lint](https://github.com/articulate/docker-articulate-node/blob/02fe1df76dddcc5f6482e954cf3ff0ca814ab4ab/.github/workflows/lint.yml#L12)
+  workflows.
 
-
-## To test locally
+## Testing Locally
 
 1. Run `make` to build a `local/articulate-node` image locally
 2. Change the first line of your `Dockerfile` to be:


### PR DESCRIPTION
Lambda now supports Node 18.

Remove yarn since there are different ways to install depending on the version. If the project is using yarn, install the version they need.

Remove the aws-sdk npm package. v3 created different packages for each service. The runtime should also provide the sdk, so we don't need that installed.

Remove the service user. This image should used for building Lambda packages, so we don't care what user the container is using.

Remove the service directory. If we want to test the Lambda locally, it assumes it's ran in /var/tasks. Our pipeline doesn't care where the working directory is.

Cleanup README. Call out the recommended images.

## New Image Checklist

If you're adding a new image, make sure you have done the following.

* [x] Added to lint workflow matrix (`.github/workflows/lint.yml`)
* [x] Added to build workflow matrix (`.github/workflows/build.yml`)
* [x] Added to Makefile (`Makefile`)
