### PR TITLE
feat: add docker-secrets script

### DIFF
--- a/16-bullseye-slim/Dockerfile
+++ b/16-bullseye-slim/Dockerfile
@@ -9,6 +9,7 @@ ENV PATH $PATH:$NODE_MODULES_PATH/.bin
 ARG TARGETARCH
 ARG AWSCLI_VERSION=2.9.15
 ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /opt/secrets
 ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 
 RUN apt-get update -qq \
@@ -28,7 +29,8 @@ RUN apt-get update -qq \
     && /tmp/aws/install \
     && rm -rf /tmp/aws /tmp/awscliv2 /tmp/awscliv2.zip \
     # Create our own user and remove the node user
-    && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
+    && groupadd --gid 1001 $SERVICE_USER \
+    && useradd --create-home --home $SERVICE_ROOT --shell /bin/bash --gid 1001 --uid 1001 $SERVICE_USER \
     && userdel -r node \
     # Install the latest version of npm
     && npm install -g npm@latest \

--- a/16-buster-slim/Dockerfile
+++ b/16-buster-slim/Dockerfile
@@ -9,6 +9,7 @@ ENV PATH $PATH:$NODE_MODULES_PATH/.bin
 ARG TARGETARCH
 ARG AWSCLI_VERSION=2.9.15
 ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /opt/secrets
 ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 
 RUN apt-get update -qq \
@@ -28,7 +29,8 @@ RUN apt-get update -qq \
     && /tmp/aws/install \
     && rm -rf /tmp/aws /tmp/awscliv2 /tmp/awscliv2.zip \
     # Create our own user and remove the node user
-    && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
+    && groupadd --gid 1001 $SERVICE_USER \
+    && useradd --create-home --home $SERVICE_ROOT --shell /bin/bash --gid 1001 --uid 1001 $SERVICE_USER \
     && userdel -r node \
     # Install the latest version of npm
     && npm install -g npm@latest \

--- a/16-lambda/Dockerfile
+++ b/16-lambda/Dockerfile
@@ -12,6 +12,7 @@ ENV YARN_VERSION 1.22.15
 ARG TARGETARCH
 ARG AWSCLI_VERSION=2.9.15
 ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /opt/secrets
 ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 COPY entrypoint-lambda.sh /
 
@@ -25,7 +26,9 @@ RUN npm install -g npm@7 \
         unzip jq sudo wget curl which \
     && yum clean all \
     && rm -rf /var/cache/yum \
-    && /usr/sbin/groupadd $SERVICE_USER && /usr/sbin/useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
+    # Add service user
+    && /usr/sbin/groupadd --gid 1001 $SERVICE_USER \
+    && /usr/sbin/useradd --create-home --home $SERVICE_ROOT --shell /bin/bash --uid 1001 --gid 1001 $SERVICE_USER \
     && ln -s /entrypoint /entrypoint.sh \
     # AWSCLI (to be removed in a future release)
     && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \

--- a/16-stretch-slim/Dockerfile
+++ b/16-stretch-slim/Dockerfile
@@ -9,6 +9,7 @@ ENV PATH $PATH:$NODE_MODULES_PATH/.bin
 ARG TARGETARCH
 ARG AWSCLI_VERSION=2.9.15
 ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /opt/secrets
 ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 
 RUN apt-get update -qq \
@@ -28,7 +29,8 @@ RUN apt-get update -qq \
     && /tmp/aws/install \
     && rm -rf /tmp/aws /tmp/awscliv2 /tmp/awscliv2.zip \
     # Create our own user and remove the node user
-    && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
+    && groupadd --gid 1001 $SERVICE_USER \
+    && useradd --create-home --home $SERVICE_ROOT --shell /bin/bash --gid 1001 --uid 1001 $SERVICE_USER \
     && userdel -r node \
     # Install the latest version of npm that has a node-gyp which works with Python 2.7
     && npm install -g npm@7 \

--- a/18-bullseye-slim/Dockerfile
+++ b/18-bullseye-slim/Dockerfile
@@ -9,6 +9,7 @@ ENV PATH $PATH:$NODE_MODULES_PATH/.bin
 ARG TARGETARCH
 ARG AWSCLI_VERSION=2.9.15
 ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /opt/secrets
 ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 
 RUN apt-get update -qq \
@@ -28,7 +29,8 @@ RUN apt-get update -qq \
     && /tmp/aws/install \
     && rm -rf /tmp/aws /tmp/awscliv2 /tmp/awscliv2.zip \
     # Create our own user and remove the node user
-    && groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER \
+    && groupadd --gid 1001 $SERVICE_USER \
+    && useradd --create-home --home $SERVICE_ROOT --shell /bin/bash --gid 1001 --uid 1001 $SERVICE_USER \
     && userdel -r node \
     # Install the latest version of npm
     && npm install -g npm@latest \

--- a/18-lambda/Dockerfile
+++ b/18-lambda/Dockerfile
@@ -5,6 +5,7 @@ ENV AWS_DEFAULT_REGION us-east-1
 
 ARG TARGETARCH
 ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /opt/secrets
 
 RUN yum -y install make zip \
     && yum clean all \


### PR DESCRIPTION
Add an /opt/secrets script to help load Docker secrets so we can more easily use secrets.

The gid/uid should default to 1001, but make it explicit since you have to mount secrets by uid.

Only including this on 16 and 18 images since Node 14 is EOL soon and we don't want to encourage using that version