### PR TITLE
refactor: move secrets to PATH

### DIFF
--- a/16-bullseye-slim/Dockerfile
+++ b/16-bullseye-slim/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH $PATH:$NODE_MODULES_PATH/.bin
 ARG TARGETARCH
 ARG AWSCLI_VERSION=2.9.15
 ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
-ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /opt/secrets
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /usr/local/bin/secrets
 ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 
 RUN apt-get update -qq \

--- a/16-buster-slim/Dockerfile
+++ b/16-buster-slim/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH $PATH:$NODE_MODULES_PATH/.bin
 ARG TARGETARCH
 ARG AWSCLI_VERSION=2.9.15
 ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
-ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /opt/secrets
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /usr/local/bin/secrets
 ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 
 RUN apt-get update -qq \

--- a/16-lambda/Dockerfile
+++ b/16-lambda/Dockerfile
@@ -12,7 +12,7 @@ ENV YARN_VERSION 1.22.15
 ARG TARGETARCH
 ARG AWSCLI_VERSION=2.9.15
 ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
-ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /opt/secrets
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /usr/local/bin/secrets
 ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 COPY entrypoint-lambda.sh /
 

--- a/16-stretch-slim/Dockerfile
+++ b/16-stretch-slim/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH $PATH:$NODE_MODULES_PATH/.bin
 ARG TARGETARCH
 ARG AWSCLI_VERSION=2.9.15
 ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
-ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /opt/secrets
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /usr/local/bin/secrets
 ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 
 RUN apt-get update -qq \

--- a/18-bullseye-slim/Dockerfile
+++ b/18-bullseye-slim/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH $PATH:$NODE_MODULES_PATH/.bin
 ARG TARGETARCH
 ARG AWSCLI_VERSION=2.9.15
 ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
-ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /opt/secrets
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /usr/local/bin/secrets
 ADD --chmod=755 https://raw.githubusercontent.com/vishnubob/wait-for-it/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh /wait-for-it.sh
 
 RUN apt-get update -qq \

--- a/18-lambda/Dockerfile
+++ b/18-lambda/Dockerfile
@@ -5,7 +5,7 @@ ENV AWS_DEFAULT_REGION us-east-1
 
 ARG TARGETARCH
 ADD --chmod=755 https://github.com/articulate/docker-consul-template-bootstrap/releases/latest/download/docker-consul-template-bootstrap_linux_${TARGETARCH} /entrypoint
-ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /opt/secrets
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/main/scripts/docker-secrets /usr/local/bin/secrets
 
 RUN yum -y install make zip \
     && yum clean all \

--- a/Makefile
+++ b/Makefile
@@ -11,49 +11,49 @@ bullseye-slim: 16-bullseye-slim 18-bullseye-slim
 .PHONY: all lambda stretch-slim buster-slim
 
 12-lambda:
-	docker build -t local/articulate-node:12-lambda 12-lambda
+	docker build -t articulate/articulate-node:12-lambda 12-lambda
 .PHONY: 12-lambda
 
 14-lambda:
-	docker build -t local/articulate-node:14-lambda 14-lambda
+	docker build -t articulate/articulate-node:14-lambda 14-lambda
 .PHONY: 14-lambda
 
 16-lambda:
-	docker build -t local/articulate-node:16-lambda 16-lambda
+	docker build -t articulate/articulate-node:16-lambda 16-lambda
 .PHONY: 16-lambda
 
 12-stretch-slim:
-	docker build -t local/articulate-node:12-stretch-slim 12-stretch-slim
+	docker build -t articulate/articulate-node:12-stretch-slim 12-stretch-slim
 .PHONY: 12-stretch-slim
 
 14-stretch-slim:
-	docker build -t local/articulate-node:14-stretch-slim 14-stretch-slim
+	docker build -t articulate/articulate-node:14-stretch-slim 14-stretch-slim
 .PHONY: 14-stretch-slim
 
 16-stretch-slim:
-	docker build -t local/articulate-node:16-stretch-slim 16-stretch-slim
+	docker build -t articulate/articulate-node:16-stretch-slim 16-stretch-slim
 .PHONY: 16-stretch-slim
 
 12-buster-slim:
-	docker build -t local/articulate-node:12-buster-slim 12-buster-slim
+	docker build -t articulate/articulate-node:12-buster-slim 12-buster-slim
 .PHONY: 12-buster-slim
 
 14-buster-slim:
-	docker build -t local/articulate-node:14-buster-slim 14-buster-slim
+	docker build -t articulate/articulate-node:14-buster-slim 14-buster-slim
 .PHONY: 14-buster-slim
 
 16-buster-slim:
-	docker build -t local/articulate-node:16-buster-slim 16-buster-slim
+	docker build -t articulate/articulate-node:16-buster-slim 16-buster-slim
 .PHONY: 16-buster-slim
 
 16-bullseye-slim:
-	docker build -t local/articulate-node:16-bullseye-slim 16-bullseye-slim
+	docker build -t articulate/articulate-node:16-bullseye-slim 16-bullseye-slim
 .PHONY: 16-bullseye-slim
 
 18-bullseye-slim:
-	docker build -t local/articulate-node:18-bullseye-slim 18-bullseye-slim
+	docker build -t articulate/articulate-node:18-bullseye-slim 18-bullseye-slim
 .PHONY: 18-bullseye-slim
 
 18-lambda:
-	docker build -t local/articulate-node:18-lambda 18-lambda
+	docker build -t articulate/articulate-node:18-lambda 18-lambda
 .PHONY: 18-lambda

--- a/README.md
+++ b/README.md
@@ -35,15 +35,6 @@ FROM articulate/articulate-node:<tag>
 
 ## Testing Locally
 
-1. Run `make` to build a `local/articulate-node` image locally
-2. Change the first line of your `Dockerfile` to be:
-
-```dockerfile
-FROM local/articulate-node
-```
-
-3. Then
-
-```shell
-docker-compose build --no-cache && docker-compose up
-```
+1. Run `make` to build a `articulate/articulate-node` image locally
+2. Run `docker compose build --no-cache`
+3. Run docker-compose as normal `docker compose up`


### PR DESCRIPTION
The `/opt/secrets` script hasn't been adopted yet, so move it to PATH to make it easier to use.

Improve local testing by building to the upstream name, then you don't have to modify Dockerfile to test