### PR TITLE
Globally add node-gyp

### DIFF
--- a/14-buster-slim/Dockerfile
+++ b/14-buster-slim/Dockerfile
@@ -33,7 +33,9 @@ RUN apt-get update -qq \
     # Install the latest version of npm
     && npm install -g npm@latest \
     # Create the node_modules directory, make it owned by service user
-    && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH
+    && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH \
+    # Add node-gyp globally to avoid installation issues attempting to install from a dependency
+    && yarn global add node-gyp
 
 # Add a strict security policy for Imagemagick (note: Imagemagick 7 is currently not available in Debian)
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml

--- a/14-buster-slim/Dockerfile
+++ b/14-buster-slim/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update -qq \
     # Create the node_modules directory, make it owned by service user
     && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH \
     # Add node-gyp globally to avoid installation issues attempting to install from a dependency
-    && yarn global add node-gyp
+    && npm install -g node-gyp
 
 # Add a strict security policy for Imagemagick (note: Imagemagick 7 is currently not available in Debian)
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml

--- a/16-bullseye-slim/Dockerfile
+++ b/16-bullseye-slim/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update -qq \
     # Create the node_modules directory, make it owned by service user
     && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH \
     # Add node-gyp globally to avoid installation issues attempting to install from a dependency
-    && yarn global add node-gyp
+    && npm install -g node-gyp
 
 # Add a strict security policy for Imagemagick (note: Imagemagick 7 is currently not available in Debian)
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml

--- a/16-bullseye-slim/Dockerfile
+++ b/16-bullseye-slim/Dockerfile
@@ -36,7 +36,9 @@ RUN apt-get update -qq \
     # Install the latest version of npm
     && npm install -g npm@latest \
     # Create the node_modules directory, make it owned by service user
-    && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH
+    && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH \
+    # Add node-gyp globally to avoid installation issues attempting to install from a dependency
+    && yarn global add node-gyp
 
 # Add a strict security policy for Imagemagick (note: Imagemagick 7 is currently not available in Debian)
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml

--- a/16-buster-slim/Dockerfile
+++ b/16-buster-slim/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update -qq \
     # Create the node_modules directory, make it owned by service user
     && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH \
     # Add node-gyp globally to avoid installation issues attempting to install from a dependency
-    && yarn global add node-gyp
+    && npm install -g node-gyp
 
 # Add a strict security policy for Imagemagick (note: Imagemagick 7 is currently not available in Debian)
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml

--- a/16-buster-slim/Dockerfile
+++ b/16-buster-slim/Dockerfile
@@ -36,7 +36,9 @@ RUN apt-get update -qq \
     # Install the latest version of npm
     && npm install -g npm@latest \
     # Create the node_modules directory, make it owned by service user
-    && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH
+    && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH \
+    # Add node-gyp globally to avoid installation issues attempting to install from a dependency
+    && yarn global add node-gyp
 
 # Add a strict security policy for Imagemagick (note: Imagemagick 7 is currently not available in Debian)
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml

--- a/18-bullseye-slim/Dockerfile
+++ b/18-bullseye-slim/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update -qq \
     # Create the node_modules directory, make it owned by service user
     && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH \
     # Add node-gyp globally to avoid installation issues attempting to install from a dependency
-    && yarn global add node-gyp
+    && npm install -g node-gyp
 
 # Add a strict security policy for Imagemagick (note: Imagemagick 7 is currently not available in Debian)
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml

--- a/18-bullseye-slim/Dockerfile
+++ b/18-bullseye-slim/Dockerfile
@@ -36,7 +36,9 @@ RUN apt-get update -qq \
     # Install the latest version of npm
     && npm install -g npm@latest \
     # Create the node_modules directory, make it owned by service user
-    && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH
+    && mkdir -p $NODE_MODULES_PATH && chown $SERVICE_USER:$SERVICE_USER $NODE_MODULES_PATH \
+    # Add node-gyp globally to avoid installation issues attempting to install from a dependency
+    && yarn global add node-gyp
 
 # Add a strict security policy for Imagemagick (note: Imagemagick 7 is currently not available in Debian)
 COPY imagemagick-policy.xml /etc/ImageMagick-6/policy.xml


### PR DESCRIPTION
Child images that attempt to install `node-gyp` are encountering errors and are failing to build.

```
#8 25.00 success Installed "node-gyp@9.4.0" with binaries:
#8 25.00       - node-gyp
#8 ERROR: process "/bin/sh -c yarn install --frozen-lockfile && yarn cache clean" did not complete successfully: exit code: 1
------
 > [4/6] RUN yarn install --frozen-lockfile && yarn cache clean:
#8 23.43 warning Error running install script for optional dependency: "/service/node_modules/msgpackr-extract: Cannot read properties of undefined (reading 'config')"
#8 23.45 error An unexpected error occurred: "/service/node_modules/@datadog/native-appsec: Cannot read properties of undefined (reading 'getOption')".
#8 23.45 info If you think this is a bug, please open a bug report with the information provided in "/service/.config/yarn/global/yarn-error.log".
#8 23.45 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
#8 23.46 [1/4] Resolving packages...
#8 24.44 [2/4] Fetching packages...
#8 24.90 [3/4] Linking dependencies...
#8 25.00 [4/4] Building fresh packages...
#8 25.00 success Installed "node-gyp@9.4.0" with binaries:
#8 25.00       - node-gyp
```

It's not clear to me what the problem is. The base `node` images were updated yesterday & seems to be the most likely cause, though i don't understand why.

Globally installing `node-gyp` resolves the issue. This adds to all buster & bullseye images.