### PR TITLE
feat(tls): Add AWS RDS CA certificates to node images

### DIFF
--- a/20/base/Dockerfile
+++ b/20/base/Dockerfile
@@ -2,18 +2,26 @@
 # syntax=docker/dockerfile:1
 FROM node:20-bookworm-slim
 
-ENV SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001
+ENV SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001 NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/aws-rds-global-bundle.pem
 
 ARG TARGETARCH
 
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/install_packages /usr/local/bin/install_packages
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/awscli.sh /tmp/awscli.sh
+# Add AWS RDS CA trusted root certificates for node
+ADD --chmod=644 https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.pem
 
-RUN install_packages make dumb-init && /tmp/awscli.sh && rm /tmp/awscli.sh \
+RUN install_packages make dumb-init ca-certificates && /tmp/awscli.sh && rm /tmp/awscli.sh \
     # Create our own user and remove the node user
     && groupadd --gid $SERVICE_UID $SERVICE_USER \
     && useradd --create-home --shell /bin/bash --gid $SERVICE_UID --uid $SERVICE_UID $SERVICE_USER \
-    && userdel -r node
+    && userdel -r node \
+    # Split PEM bundle into individual cert files for update-ca-certificates
+    && csplit -s -z -n 3 -f /usr/local/share/ca-certificates/aws-rds-ca- \
+      /usr/local/share/ca-certificates/aws-rds-global-bundle.pem  \
+      '/-----BEGIN CERTIFICATE-----/' '{*}' \
+    && for f in /usr/local/share/ca-certificates/aws-rds-ca-*; do mv "$f" "$f.crt"; done \
+    && update-ca-certificates
 
 ADD --chmod=755 https://github.com/articulate/docker-bootstrap/releases/latest/download/docker-bootstrap_linux_${TARGETARCH} /entrypoint
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/docker-secrets /usr/local/bin/secrets

--- a/22/base/Dockerfile
+++ b/22/base/Dockerfile
@@ -2,21 +2,29 @@
 # syntax=docker/dockerfile:1
 FROM node:22-bookworm-slim
 
-ENV SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001
+ENV SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001 NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/aws-rds-global-bundle.pem
 
 ARG TARGETARCH
 
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/install_packages /usr/local/bin/install_packages
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/awscli.sh /tmp/awscli.sh
+# Add AWS RDS CA trusted root certificates for node
+ADD --chmod=644 https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.pem
 
-RUN install_packages make dumb-init && /tmp/awscli.sh && rm /tmp/awscli.sh \
+RUN install_packages make dumb-init ca-certificates && /tmp/awscli.sh && rm /tmp/awscli.sh \
     # Create our own user and remove the node user
     && groupadd --gid $SERVICE_UID $SERVICE_USER \
     && useradd --create-home --shell /bin/bash --gid $SERVICE_UID --uid $SERVICE_UID $SERVICE_USER \
     && userdel -r node \
     # Enable Corepack
     && npm install --global corepack@0.33.0 \
-    && corepack enable
+    && corepack enable \
+    # Split PEM bundle into individual cert files for update-ca-certificates
+    && csplit -s -z -n 3 -f /usr/local/share/ca-certificates/aws-rds-ca- \
+      /usr/local/share/ca-certificates/aws-rds-global-bundle.pem  \
+      '/-----BEGIN CERTIFICATE-----/' '{*}' \
+    && for f in /usr/local/share/ca-certificates/aws-rds-ca-*; do mv "$f" "$f.crt"; done \
+    && update-ca-certificates
 
 ADD --chmod=755 https://github.com/articulate/docker-bootstrap/releases/latest/download/docker-bootstrap_linux_${TARGETARCH} /entrypoint
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/docker-secrets /usr/local/bin/secrets

--- a/24/base/Dockerfile
+++ b/24/base/Dockerfile
@@ -2,21 +2,29 @@
 # syntax=docker/dockerfile:1
 FROM node:24-bookworm-slim
 
-ENV SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001
+ENV SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001 NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/aws-rds-global-bundle.pem
 
 ARG TARGETARCH
 
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/install_packages /usr/local/bin/install_packages
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/awscli.sh /tmp/awscli.sh
+# Add AWS RDS CA trusted root certificates for node
+ADD --chmod=644 https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/aws-rds-global-bundle.pem
 
-RUN install_packages make dumb-init && /tmp/awscli.sh && rm /tmp/awscli.sh \
+RUN install_packages make dumb-init ca-certificates && /tmp/awscli.sh && rm /tmp/awscli.sh \
     # Create our own user and remove the node user
     && groupadd --gid $SERVICE_UID $SERVICE_USER \
     && useradd --create-home --shell /bin/bash --gid $SERVICE_UID --uid $SERVICE_UID $SERVICE_USER \
     && userdel -r node \
     # Enable Corepack
     && npm install --global corepack@0.33.0 \
-    && corepack enable
+    && corepack enable \
+    # Split PEM bundle into individual cert files for update-ca-certificates
+    && csplit -s -z -n 3 -f /usr/local/share/ca-certificates/aws-rds-ca- \
+      /usr/local/share/ca-certificates/aws-rds-global-bundle.pem  \
+      '/-----BEGIN CERTIFICATE-----/' '{*}' \
+    && for f in /usr/local/share/ca-certificates/aws-rds-ca-*; do mv "$f" "$f.crt"; done \
+    && update-ca-certificates
 
 ADD --chmod=755 https://github.com/articulate/docker-bootstrap/releases/latest/download/docker-bootstrap_linux_${TARGETARCH} /entrypoint
 ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/docker-secrets /usr/local/bin/secrets

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Base Node.js Docker images.
   to install apt packages.
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
   for interacting with AWS services.
+* [AWS RDS CA Certificates](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html)
+  to enable trusted TLS connections with AWS RDS instances _(in any region)_.
 
 ## Tags
 


### PR DESCRIPTION
Add [AWS RDS CA certificates](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) to enable trusted TLS connections with RDS in any region.
- Sets env var `NODE_EXTRA_CA_CERTS` for node.
- Adds the certs to the OS trust store with `update-ca-certificates`.
- _Related to Slack conversations [here](https://articulate.slack.com/archives/CKFUF179T/p1766160735025729) and [here](https://articulate.slack.com/archives/C2QFA5938/p1767067851722719?thread_ts=1767040162.264079&cid=C2QFA5938), caused by attempts to upgrade to PostgreSQL 17._