### PR TITLE
feat: add Node.js 24 lambda image

### DIFF
--- a/24/base/Dockerfile
+++ b/24/base/Dockerfile
@@ -17,7 +17,7 @@ RUN install_packages make dumb-init ca-certificates && /tmp/awscli.sh && rm /tmp
     && useradd --create-home --shell /bin/bash --gid $SERVICE_UID --uid $SERVICE_UID $SERVICE_USER \
     && userdel -r node \
     # Enable Corepack
-    && npm install --global corepack@0.33.0 \
+    && npm install --global corepack@0.34.6 \
     && corepack enable \
     # Split PEM bundle into individual cert files for update-ca-certificates
     && csplit -s -z -n 3 -f /usr/local/share/ca-certificates/aws-rds-ca- \

--- a/24/lambda/Dockerfile
+++ b/24/lambda/Dockerfile
@@ -1,0 +1,30 @@
+# tags=articulate/node:24-lambda
+# syntax=docker/dockerfile:1
+FROM amazon/aws-lambda-nodejs:24
+
+ENV AWS_DEFAULT_REGION=us-east-1 SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001 COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
+ARG TARGETARCH
+
+RUN dnf -y install make zip shadow-utils \
+    # Add service user
+    && /usr/sbin/groupadd --gid $SERVICE_UID $SERVICE_USER \
+    && /usr/sbin/useradd --create-home --shell /bin/bash --uid $SERVICE_UID --gid $SERVICE_UID $SERVICE_USER \
+    # Enable Corepack
+    && npm install --global corepack@0.34.6 \
+    && corepack enable \
+    # clean up
+    && dnf -y remove shadow-utils \
+    && dnf clean all \
+    && npm cache clean --force
+
+ADD --chmod=755 https://github.com/articulate/docker-bootstrap/releases/latest/download/docker-bootstrap_linux_${TARGETARCH} /entrypoint
+ADD --chmod=755 https://raw.githubusercontent.com/articulate/docker-bootstrap/main/scripts/docker-secrets /usr/local/bin/secrets
+
+USER $SERVICE_USER
+WORKDIR $SERVICE_ROOT
+
+# Our entrypoint will pull in our environment variables from Consul and Vault,
+# and execute whatever command we provided the container.
+# See https://github.com/articulate/docker-bootstrap
+ENTRYPOINT [ "/entrypoint" ]

--- a/24/lambda/Dockerfile
+++ b/24/lambda/Dockerfile
@@ -1,6 +1,6 @@
 # tags=articulate/node:24-lambda
 # syntax=docker/dockerfile:1
-FROM amazon/aws-lambda-nodejs:24
+FROM public.ecr.aws/lambda/nodejs:24
 
 ENV AWS_DEFAULT_REGION=us-east-1 SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001 COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Base Node.js Docker images.
 > 🌟 recommended image
 
 * __articulate/node:24__ 🌟
+* articulate/node:24-lambda
 * __articulate/node:22__ 🌟
 * articulate/node:22-lambda
 * __articulate/node:20__


### PR DESCRIPTION
- Add new 24/lambda/Dockerfile based on aws-lambda-nodejs:24
- Update corepack from 0.33.0 to 0.34.6 in Node 24
- Update README with 24-lambda variant

# New Image Checklist

If you're adding a new image, make sure you have done the following:

* [x] Ensure Dockerfile has a `# tag=` comment with the correct tag(s)
* [x] Tag is added to README.md
