### PR TITLE
ci(auto-merge): add workflow to auto-merge dependency PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 * @articulate/devex
+
+# Allow Botzo to approve dependency bumps (and related updates)
+/.github/workflows/ @articulate/devex @botzo

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,28 @@
+name: Auto-merge Dependencies
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ${{ vars.RUNNER_SMALL }}
+    if: >
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'articulate-automation[bot]'
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: token
+        with:
+          client-id: ${{ vars.AUTOMATION_CLIENT_ID }}
+          private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
+      - name: Approve PR
+        env:
+          # Approve as Botzo to work around CODEOWNERS requirement
+          GH_TOKEN: ${{ secrets.BOTZO_GH_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: gh pr review --approve "$PR" -R "$GITHUB_REPOSITORY"
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: gh pr merge --auto --squash "$PR" -R "$GITHUB_REPOSITORY"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,22 +2,23 @@ name: Build
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main
   schedule:
-    - cron: '0 0 * * 1-6'
-    - cron: '0 0 * * 0' # runs with no-cache
+    - cron: "0 0 * * 1-6"
+    - cron: "0 0 * * 0" # runs with no-cache
   workflow_dispatch:
     inputs:
       no-cache:
-        description: 'Skip Docker cache'
+        description: "Skip Docker cache"
         type: boolean
         default: false
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - name: Find Dockerfiles
@@ -50,17 +51,25 @@ jobs:
       - uses: docker/build-push-action@v7
         with:
           context: ${{ steps.meta.outputs.context }}
-          pull: ${{ github.event_name != 'pull_request' }}
-          push: ${{ github.event_name != 'pull_request' }}
+          pull: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
+          push: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64/v8
           cache-from: type=registry,ref=${{ steps.meta.outputs.cache }}
           cache-to: type=inline
           no-cache: ${{ github.event.schedule == '0 0 * * 0' || (github.event_name == 'workflow_dispatch' && inputs.no-cache) }}
+  build-complete:
+    if: always()
+    runs-on: ubuntu-slim
+    needs: [build]
+    steps:
+      - name: Verify build succeeded
+        run: |
+          [ "${{ needs.build.result }}" = "success" ] || exit 1
   dockerhub:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: build
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
     steps:
       - uses: actions/checkout@v6
       - uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # pin@v4
@@ -70,8 +79,8 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           short-description: ${{ github.event.repository.description }}
   notify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: build
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
     steps:
       - run: curl ${{ secrets.DMS_URL }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,12 @@
 name: Lint
 
-on: pull_request
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - name: Find Dockerfiles
@@ -25,3 +27,11 @@ jobs:
         with:
           dockerfile: ${{ matrix.dockerfile }}
           ignore: DL3008,DL3016,DL3033,DL3041
+  lint-complete:
+    if: always()
+    runs-on: ubuntu-slim
+    needs: [lint]
+    steps:
+      - name: Verify lint succeeded
+        run: |
+          [ "${{ needs.lint.result }}" = "success" ] || exit 1


### PR DESCRIPTION
Add a complete step for build and lint so we can add rulesets to require these to pass before merging.

Moving some small jobs over to ubuntu-slim