### PR TITLE
fix: pin node 22/24 images to pre-regression versions

### DIFF
--- a/22/base/Dockerfile
+++ b/22/base/Dockerfile
@@ -1,6 +1,8 @@
 # tags=articulate/node:22
 # syntax=docker/dockerfile:1
-FROM node:22-bookworm-slim
+# Pinned to 22.22.x; Node 22.23.0 broke node-fetch@2 keep-alive (ERR_STREAM_PREMATURE_CLOSE).
+# Unpin once 22.23.1+/22.24.0 ships. See https://github.com/nodejs/node/issues/63989
+FROM node:22.22-bookworm-slim
 
 ENV SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001 NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/aws-rds-global-bundle.pem
 

--- a/22/lambda/Dockerfile
+++ b/22/lambda/Dockerfile
@@ -1,6 +1,9 @@
 # tags=articulate/node:22-lambda
 # syntax=docker/dockerfile:1
-FROM amazon/aws-lambda-nodejs:22
+# Pinned to the 2026-05-05 Lambda Node 22 build; Node 22.23.0 broke node-fetch@2 keep-alive
+# (ERR_STREAM_PREMATURE_CLOSE). Unpin once AWS rebuilds on 22.23.1+/22.24.0.
+# See https://github.com/nodejs/node/issues/63989
+FROM amazon/aws-lambda-nodejs:22.2026.05.05.20-x86_64
 
 ENV AWS_DEFAULT_REGION=us-east-1 SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001 COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 

--- a/24/base/Dockerfile
+++ b/24/base/Dockerfile
@@ -1,6 +1,8 @@
 # tags=articulate/node:24
 # syntax=docker/dockerfile:1
-FROM node:24-bookworm-slim
+# Pinned to 24.16.x; Node 24.17.0 broke node-fetch@2 keep-alive (ERR_STREAM_PREMATURE_CLOSE).
+# Unpin once 24.17.1+/24.18.0 ships. See https://github.com/nodejs/node/issues/63989
+FROM node:24.16-bookworm-slim
 
 ENV SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001 NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/aws-rds-global-bundle.pem
 

--- a/24/lambda/Dockerfile
+++ b/24/lambda/Dockerfile
@@ -1,6 +1,9 @@
 # tags=articulate/node:24-lambda
 # syntax=docker/dockerfile:1
-FROM public.ecr.aws/lambda/nodejs:24
+# Pinned to the 2026-05-05 Lambda Node 24 build; Node 24.17.0 broke node-fetch@2 keep-alive
+# (ERR_STREAM_PREMATURE_CLOSE). Unpin once AWS rebuilds on 24.17.1+/24.18.0.
+# See https://github.com/nodejs/node/issues/63989
+FROM public.ecr.aws/lambda/nodejs:24.2026.05.05.20
 
 ENV AWS_DEFAULT_REGION=us-east-1 SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001 COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@ Base Node.js Docker images.
 * __articulate/node:20__
 * articulate/node:20-lambda
 
+### Upstream Node pin (June 23 2026)
+
+Node 22 and 24 base images are temporarily pinned to pre-regression versions:
+
+* `node:22` → `node:22.22-bookworm-slim`
+* `node:22-lambda` → `amazon/aws-lambda-nodejs:22.2026.05.05.20-x86_64`
+* `node:24` → `node:24.16-bookworm-slim`
+* `node:24-lambda` → `public.ecr.aws/lambda/nodejs:24.2026.05.05.20`
+
+Node 22.23.0 and 24.17.0 (2026-06-18 security release for CVE-2026-48931)
+regressed `http.Agent` keep-alive handling, breaking `node-fetch@2` (and the
+entire `gaxios` → `googleapis` / `@google-cloud` / `firebase-tools` stack) with
+`ERR_STREAM_PREMATURE_CLOSE` under load. Unpin once 22.23.1+/22.24.0 and
+24.17.1+/24.18.0 ship.
+
+* Issue: <https://github.com/nodejs/node/issues/63989>
+* Fix PR: <https://github.com/nodejs/node/pull/64004>
+
 ### articulate/node vs articulate/articulate-node
 
 `articulate/articulate-node` are the legacy Docker images. Those ran as root and


### PR DESCRIPTION
Node 22.23.0 and 24.17.0 (2026-06-18 security release for CVE-2026-48931)
regressed http.Agent keep-alive handling, breaking node-fetch@2 (and the
gaxios -> googleapis / @google-cloud / firebase-tools stack) with
ERR_STREAM_PREMATURE_CLOSE under load.

Pin back to the prior minor line until a fixed patch ships:

- 22/base:   node:22.22-bookworm-slim
- 22/lambda: amazon/aws-lambda-nodejs:22.2026.05.05.20-x86_64
- 24/base:   node:24.16-bookworm-slim
- 24/lambda: public.ecr.aws/lambda/nodejs:24.2026.05.05.20

Unpin once 22.23.1+/22.24.0 and 24.17.1+/24.18.0 ship.

Refs: https://github.com/nodejs/node/issues/63989
Fix PR: https://github.com/nodejs/node/pull/64004
