### PR TITLE
revert: unpin node 22/24 images (upstream regression resolved)

### DIFF
--- a/22/base/Dockerfile
+++ b/22/base/Dockerfile
@@ -1,8 +1,6 @@
 # tags=articulate/node:22
 # syntax=docker/dockerfile:1
-# Pinned to 22.22.x; Node 22.23.0 broke node-fetch@2 keep-alive (ERR_STREAM_PREMATURE_CLOSE).
-# Unpin once 22.23.1+/22.24.0 ships. See https://github.com/nodejs/node/issues/63989
-FROM node:22.22-bookworm-slim
+FROM node:22-bookworm-slim
 
 ENV SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001 NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/aws-rds-global-bundle.pem
 

--- a/22/lambda/Dockerfile
+++ b/22/lambda/Dockerfile
@@ -1,9 +1,6 @@
 # tags=articulate/node:22-lambda
 # syntax=docker/dockerfile:1
-# Pinned to the 2026-05-05 Lambda Node 22 build; Node 22.23.0 broke node-fetch@2 keep-alive
-# (ERR_STREAM_PREMATURE_CLOSE). Unpin once AWS rebuilds on 22.23.1+/22.24.0.
-# See https://github.com/nodejs/node/issues/63989
-FROM amazon/aws-lambda-nodejs:22.2026.05.05.20-x86_64
+FROM amazon/aws-lambda-nodejs:22
 
 ENV AWS_DEFAULT_REGION=us-east-1 SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001 COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 

--- a/24/base/Dockerfile
+++ b/24/base/Dockerfile
@@ -1,8 +1,6 @@
 # tags=articulate/node:24
 # syntax=docker/dockerfile:1
-# Pinned to 24.16.x; Node 24.17.0 broke node-fetch@2 keep-alive (ERR_STREAM_PREMATURE_CLOSE).
-# Unpin once 24.17.1+/24.18.0 ships. See https://github.com/nodejs/node/issues/63989
-FROM node:24.16-bookworm-slim
+FROM node:24-bookworm-slim
 
 ENV SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001 NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/aws-rds-global-bundle.pem
 

--- a/24/lambda/Dockerfile
+++ b/24/lambda/Dockerfile
@@ -1,9 +1,6 @@
 # tags=articulate/node:24-lambda
 # syntax=docker/dockerfile:1
-# Pinned to the 2026-05-05 Lambda Node 24 build; Node 24.17.0 broke node-fetch@2 keep-alive
-# (ERR_STREAM_PREMATURE_CLOSE). Unpin once AWS rebuilds on 24.17.1+/24.18.0.
-# See https://github.com/nodejs/node/issues/63989
-FROM public.ecr.aws/lambda/nodejs:24.2026.05.05.20
+FROM public.ecr.aws/lambda/nodejs:24
 
 ENV AWS_DEFAULT_REGION=us-east-1 SERVICE_ROOT=/service SERVICE_USER=service SERVICE_UID=1001 COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 

--- a/README.md
+++ b/README.md
@@ -26,24 +26,6 @@ Base Node.js Docker images.
 * __articulate/node:20__
 * articulate/node:20-lambda
 
-### Upstream Node pin (June 23 2026)
-
-Node 22 and 24 base images are temporarily pinned to pre-regression versions:
-
-* `node:22` → `node:22.22-bookworm-slim`
-* `node:22-lambda` → `amazon/aws-lambda-nodejs:22.2026.05.05.20-x86_64`
-* `node:24` → `node:24.16-bookworm-slim`
-* `node:24-lambda` → `public.ecr.aws/lambda/nodejs:24.2026.05.05.20`
-
-Node 22.23.0 and 24.17.0 (2026-06-18 security release for CVE-2026-48931)
-regressed `http.Agent` keep-alive handling, breaking `node-fetch@2` (and the
-entire `gaxios` → `googleapis` / `@google-cloud` / `firebase-tools` stack) with
-`ERR_STREAM_PREMATURE_CLOSE` under load. Unpin once 22.23.1+/22.24.0 and
-24.17.1+/24.18.0 ship.
-
-* Issue: <https://github.com/nodejs/node/issues/63989>
-* Fix PR: <https://github.com/nodejs/node/pull/64004>
-
 ### articulate/node vs articulate/articulate-node
 
 `articulate/articulate-node` are the legacy Docker images. Those ran as root and


### PR DESCRIPTION
Reverts e1dae61.

Node team shipped updated node:22 and node:24 images that include the
fix for the ERR_STREAM_PREMATURE_CLOSE regression introduced in the
June 18 CVE-2026-48931 security release. Version pins and the
accompanying README note are no longer needed.
